### PR TITLE
(#24) Implement support for cypress app init

### DIFF
--- a/cypress/integration/common/beforeEach.js
+++ b/cypress/integration/common/beforeEach.js
@@ -1,0 +1,21 @@
+
+// Call to reinitialize application.
+
+beforeEach(() => {
+  cy.on('window:before:load', (win) => {
+    // This is the only setting that needs to be set across each application
+    // load. this needs to occur before cy.visit() which will request the
+    // page. Setting all defaults in order to make sure that a change
+    // to development defaults does not break a bunch of texts.
+    win.INT_TEST_APP_PARAMS = { 
+      audience: 'Patient',
+      basePath: '/',
+      dictionaryEndpoint: "/api",
+      dictionaryName: 'Cancer.gov',
+      dictionaryTitle: 'NCI Dictionary of Cancer Terms',
+      dictionaryIntoText: 'Intro Text',
+      language: 'en'
+    }
+    console.log(win.INT_TEST_APP_PARAMS)
+  });
+});

--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,19 @@ import * as serviceWorker from "./serviceWorker";
 import { ClientContextProvider } from 'react-fetching-library';
 import { getAxiosClient } from './services/api/axios-client';
 
+// Default settings for development.
+// This can be overridden by integration tests.
+const defaultDevSettings = {
+  analyticsHandler: (data) => { console.log(data); },
+  audience: 'Patient',
+  basePath: '/',
+  dictionaryEndpoint: "/api",
+  dictionaryName: 'Cancer.gov',
+  dictionaryTitle: 'NCI Dictionary of Cancer Terms',
+  dictionaryIntoText: 'Intro Text',
+  language: 'en'
+}
+
 const initialize = ({
   appId = "@@/DEFAULT_DICTIONARY",
   analyticsHandler = data => {},
@@ -95,13 +108,15 @@ const getProductTestBase = () => {
 
 // The following lets us run the app in dev not in situ as would normally be the case.
 if (process.env.NODE_ENV !== "production") {
-  initialize({
-    analyticsHandler: (data) => { console.log(data); },
-    audience: 'Patient',
-    dictionaryEndpoint: "/api",
-    dictionaryName: 'Cancer.gov',
-    dictionaryIntroText: 'NCI Dictionary of Cancer Terms'
-  });
+
+  const integrationTestOverrides = window.INT_TEST_APP_PARAMS || {};
+  const initSettings = {
+    ...defaultDevSettings,
+    ...integrationTestOverrides
+  };
+
+  initialize(initSettings);
+  
 } else if (window?.location?.host === 'react-app-dev.cancer.gov') {
   // This is for product testing
   initialize({


### PR DESCRIPTION
- BeforeEach to setup window object (INT_TEST_APP_PARAMS) that overrides
  dev settings passed to initialize()
- Updated index to use INT_TEST_APP_PARAMS to override default dev
   settings when integration tests are running

Closes #24 - this should be the last item?