### PR TITLE
(#110) API Failure Error Page

### DIFF
--- a/cypress/integration/ApiFailurePage.feature
+++ b/cypress/integration/ApiFailurePage.feature
@@ -1,0 +1,10 @@
+Feature: As a user, I need to encounter an error page when a call to the API fails.
+
+    Background:
+        Given "audience" is set to ""
+        And "language" is set to "en"
+        And "dictionaryName" is set to ""
+
+    Scenario: User encounters an error page when API fails
+        Given the user is viewing the definition with the pretty url "metastatic"
+        Then the user gets an error page that reads "An error occurred. Please try again later."

--- a/cypress/integration/ApiFailureSpanishPage.feature
+++ b/cypress/integration/ApiFailureSpanishPage.feature
@@ -1,0 +1,10 @@
+Feature: As a user, I need to encounter a Spanish error page when a call to the API fails.
+
+    Background:
+        Given "audience" is set to ""
+        And "language" is set to "es"
+        And "dictionaryName" is set to ""
+
+    Scenario: User encounters an error page when API fails
+        Given the user is viewing the definition with the pretty url "metastásico"
+        Then the user gets an error page that reads "Se produjo un error. Por favor, vuelva a intentar más tarde."

--- a/cypress/integration/MetaTagsInUntranslatedApp.feature
+++ b/cypress/integration/MetaTagsInUntranslatedApp.feature
@@ -9,6 +9,6 @@ Feature: As a user, I want metadata on the page, so that I can share the web pag
         And "siteName" is set to "National Cancer Institute"
 
     Scenario: View page works when there translated defs in an untranslated app
-        Given the user is viewing the definition with the pretty url "metastatic"
-        Then the page title is "metastatic"
+        Given the user is viewing the definition with the pretty url "metastatic-untranslated"
+        Then the page title is "metastatic-untranslated"
         And there are no alternate links

--- a/cypress/integration/SitewideLanguageToggle.feature
+++ b/cypress/integration/SitewideLanguageToggle.feature
@@ -9,7 +9,7 @@ Feature: Sitewide Language Toggle
 
     Scenario: Toggle for a expanded term points to the main page of the translation
         Given user is on the dictionary landing page or results page
-        When user selects letter "M" from A-Z list
+        When user selects letter "A" from A-Z list
         Then the language toggle should have the URL path "/espanol/publicaciones/diccionario"
 
 # Scenario: Toggle for a expanded term points to the main page of the translation

--- a/cypress/integration/SitewideLanguageToggleSpanish.feature
+++ b/cypress/integration/SitewideLanguageToggleSpanish.feature
@@ -2,6 +2,7 @@ Feature: Sitewide Language Toggle Spanish
 
 Background:
     Given "language" is set to "es"
+    And "dictionaryTitle" is set to "Diccionario de cáncer"
     And "altLanguageDictionaryBasePath" is set to "/publications/dictionaries/cancer-terms"
 
     Scenario: Toggle for a definition points to a translation
@@ -10,7 +11,7 @@ Background:
 
     Scenario: Toggle for a expanded term points to the main page of the translation
         Given user is on the dictionary landing page or results page
-        When user selects letter "M" from A-Z list
+        When user selects letter "A" from A-Z list
         Then the language toggle should have the URL path "/publications/dictionaries/cancer-terms"
 
 # Scenario: Toggle for a expanded term points to the main page of the translation

--- a/cypress/integration/ViewTermsByLetter.feature
+++ b/cypress/integration/ViewTermsByLetter.feature
@@ -3,7 +3,7 @@ Feature: View Terms by letter
 
   Scenario: User appends /expand to the URL and tries to access the dictionary
     Given user appends "/expand" to the URL
-    When user tries to go to this URL, system should return the "No Matches Found" page
+    When user tries to go to this URL, system should return the "No Matches Found" page for language "en"
 
   Scenario: User selects a letter from A-Z list on dictionaries
     Given user is on the dictionary landing page or results page

--- a/cypress/integration/ViewTermsByLetterSpanish.feature
+++ b/cypress/integration/ViewTermsByLetterSpanish.feature
@@ -2,15 +2,19 @@ Feature: View Terms by letter Spanish
 
   Background:
     Given "language" is set to "es"
+    And "altLanguageDictionaryBasePath" is set to "/publications/dictionaries/cancer-terms"
+
+  Scenario: User appends /expand to the URL and tries to access the dictionary
+    Given user appends "/ampliar" to the URL
+    When user tries to go to this URL, system should return the "No Matches Found" page for language "es"
 
   Scenario: User selects a letter from A-Z list on dictionaries
     Given user is on the dictionary landing page or results page
-    When user selects letter "M" from A-Z list
-    Then search results page displays results title "# resultados de: M"
+    When user selects letter "A" from A-Z list
+    Then search results page displays results title "# resultados de: A"
     And each result in the results listing appears as a link to the term's page
     And each result displays its full definition below the link for the term
 
   Scenario: Results /ampliar page metadata
-    Given "language" is set to "es"
     Given the user is viewing a results page based on clicking a letter like "A" in the dictionary
     Then '<meta name="robots" content="noindex" />' exists in the data for the page URL of "/ampliar/A"

--- a/cypress/integration/common/beforeEach.js
+++ b/cypress/integration/common/beforeEach.js
@@ -2,24 +2,27 @@
 // Call to reinitialize application.
 
 beforeEach(() => {
-  cy.on('window:before:load', (win) => {
+  cy.on("window:before:load", (win) => {
     // This is the only setting that needs to be set across each application
     // load. this needs to occur before cy.visit() which will request the
     // page. Setting all defaults in order to make sure that a change
     // to development defaults does not break a bunch of texts.
-    win.INT_TEST_APP_PARAMS = { 
-      audience: 'Patient',
-      basePath: '',
-      baseHost: 'http://localhost:3000',
+    win.INT_TEST_APP_PARAMS = {
+      altLanguageDictionaryBasePath: "/espanol/publicaciones/diccionario",
+      audience: "Patient",
+      baseHost: "http://localhost:3000",
+      basePath: "",
+      canonicalHost: "https://www.cancer.gov",
       dictionaryEndpoint: "/api",
-      dictionaryName: 'Cancer.gov',
-      dictionaryTitle: 'NCI Dictionary of Cancer Terms',
-      dictionaryIntroText: 'Intro Text',
-      language: 'en',
-      canonicalHost: 'https://www.cancer.gov',
-      altLanguageDictionaryBasePath: "",
-      siteName: 'National Cancer Institute'
-    }
+      dictionaryIntroText: "<p>The NCI Dictionary of Cancer Terms features <strong>{{term_count}}</strong> terms related to cancer and medicine.</p>" +
+        "<p>We offer a widget that you can add to your website to let users look up cancer-related terms. <a href=\"/syndication/widgets\">Get NCI’s Dictionary of Cancer Terms Widget</a></p>",
+      dictionaryName: "Cancer.gov",
+      dictionaryTitle: "NCI Dictionary of Cancer Terms",
+      language: "en",
+      searchBoxTitle: "Search NCI's Dictionary of Cancer Terms",
+      siteName: "National Cancer Institute"
+    };
     console.log(win.INT_TEST_APP_PARAMS)
   });
 });
+

--- a/cypress/integration/common/index.js
+++ b/cypress/integration/common/index.js
@@ -1,5 +1,10 @@
 import { And, Given, Then, When } from "cypress-cucumber-preprocessor/steps";
-import { NO_MATCHING_TEXT_EXPAND, queryType, testIds } from "../../../src/constants";
+import {
+  NO_MATCHING_TEXT_EXPAND,
+  NO_MATCHING_TEXT_EXPAND_SPANISH,
+  queryType,
+  testIds
+} from "../../../src/constants";
 
 const baseURL = Cypress.config('baseUrl');
 
@@ -305,8 +310,12 @@ Then('there is an resource item with the following link and text',dataTable =>{
     ------------------------------
 */
 
-When('user tries to go to this URL, system should return the {string} page', (text) => {
-  cy.get(`p[data-testid='${testIds.NO_MATCHING_RESULTS}']`).should('have.text', NO_MATCHING_TEXT_EXPAND);
+When('user tries to go to this URL, system should return the {string} page for language {string}', (text, lang) => {
+  cy.get(`p[data-testid='${testIds.NO_MATCHING_RESULTS}']`)
+      .should(
+          'have.text',
+          lang === 'es' ? NO_MATCHING_TEXT_EXPAND_SPANISH : NO_MATCHING_TEXT_EXPAND
+      );
 });
 
 Then('the system returns user to the search results page for the search term {string} URL has {string}', (term, destURL) => {
@@ -413,3 +422,19 @@ Then('{string} exists in the data for the page', (noIndexDirective) => {
 Then('the language toggle should have the URL path {string}',(urlPath)=>{
 cy.get('#LangList1 a').should('have.attr','href').and('to.be.eq',urlPath);
 })
+
+
+/*
+    ----------------------------------------
+       API Error Page
+    ----------------------------------------
+*/
+
+Then('the user gets an error page that reads {string}',(errorMessage)=>{
+  Cypress.on('uncaught:exception', (err, runnable) => {
+    // returning false here to Cypress from
+    // failing the test
+    return false
+  })
+  cy.get('.error-container h1').should('have.text',errorMessage);
+});

--- a/src/App.js
+++ b/src/App.js
@@ -4,7 +4,7 @@ import track from "react-tracking";
 
 import "./styles/dictionaries.scss";
 
-import { useAppPaths } from "./hooks/routing";
+import { useAppPaths } from "./hooks";
 import Definition from './views/Definition';
 import Home from './views/Home';
 

--- a/src/__tests__/App.test.js
+++ b/src/__tests__/App.test.js
@@ -6,7 +6,7 @@ import { ClientContextProvider } from "react-fetching-library";
 import { MemoryRouter, useLocation } from "react-router";
 
 import { queryType } from "../constants";
-import { useAppPaths } from "../hooks/routing";
+import { useAppPaths } from "../hooks";
 import { getAxiosClient } from "../services/api/axios-client";
 import { useStateValue } from "../store/store.js";
 import Definition from "../views/Definition";

--- a/src/components/atomic/az-list/AZList.jsx
+++ b/src/components/atomic/az-list/AZList.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import { Link } from "react-router-dom";
 
 import { AZListArray, testIds } from "../../../constants";
-import { useAppPaths } from "../../../hooks/routing";
+import { useAppPaths } from "../../../hooks";
 import { useStateValue } from "../../../store/store";
 import { i18n } from "../../../utils/i18n";
 

--- a/src/components/molecules/related-resource-list/related-resource-list.jsx
+++ b/src/components/molecules/related-resource-list/related-resource-list.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Link } from "react-router-dom";
-import { useAppPaths } from "../../../hooks/routing";
+import { useAppPaths } from "../../../hooks";
 
 const RelatedResourceList = ({ linksArr, lang = "en" }) => {
   const { DefinitionPath } = useAppPaths();

--- a/src/constants.js
+++ b/src/constants.js
@@ -8,6 +8,7 @@ export const DEFAULT_RESULT_SIZE = 10000;
 
 // No Matching text
 export const NO_MATCHING_TEXT_EXPAND = "No matches were found for your selected letter. Please try a new search, or click a different letter in the alphabet and browse through the list of terms that begin with that letter.";
+export const NO_MATCHING_TEXT_EXPAND_SPANISH = "No matches were found for your selected letter. Please try a new search, or click a different letter in the alphabet and browse through the list of terms that begin with that letter.";
 
 export const searchMatchType = {
   beginsWith: 'Begins',

--- a/src/hooks/__tests__/customFetch.tests.js
+++ b/src/hooks/__tests__/customFetch.tests.js
@@ -1,0 +1,86 @@
+import { act, render } from "@testing-library/react";
+import React from "react";
+import { ClientContextProvider } from "react-fetching-library";
+
+import UseCustomQuerySample from "../samples/UseCustomQuery";
+import { useStateValue } from "../../store/store";
+import { i18n } from "../../utils";
+import ErrorBoundary from "../../views/ErrorBoundary";
+
+jest.mock("../../store/store");
+
+let client;
+let wrapper;
+describe( '', () => {
+
+    test('useCustomQuery example should throw error - English message', async () => {
+        const language = "en";
+        useStateValue.mockReturnValue([{ language }]);
+        client = {
+            query: async () => ({
+                error: true,
+                status: 500,
+                payload: {}
+            })
+        };
+        await act( async () => {
+            wrapper = render(
+                <ClientContextProvider client={ client }>
+                    <ErrorBoundary>
+                        <UseCustomQuerySample />
+                    </ErrorBoundary>
+                </ClientContextProvider>
+            );
+        });
+        const { getByText } = wrapper;
+        expect( getByText( i18n.errorPageText[language]) ).toBeInTheDocument();
+   });
+
+    test('useCustomQuery example should throw error - Spanish message', async () => {
+        const language = "es";
+        useStateValue.mockReturnValue([{ language }]);
+        client = {
+            query: async () => ({
+                error: true,
+                status: 500,
+                payload: {}
+            })
+        };
+        await act( async () => {
+            wrapper = render(
+                <ClientContextProvider client={ client }>
+                    <ErrorBoundary>
+                        <UseCustomQuerySample />
+                    </ErrorBoundary>
+                </ClientContextProvider>
+            );
+        });
+        const { getByText } = wrapper;
+        expect( getByText( i18n.errorPageText[language]) ).toBeInTheDocument();
+    });
+
+    test('useCustomQuery example should display content and not throw error', async () => {
+        const language = "en";
+        const contentMessage = "Successful API call with content";
+        useStateValue.mockReturnValue([{ language }]);
+
+        client = {
+            query: async () => ({
+                error: false,
+                status: 200,
+                payload: { contentMessage }
+            })
+        };
+        await act( async () => {
+            wrapper = render(
+                <ClientContextProvider client={ client }>
+                    <ErrorBoundary>
+                        <UseCustomQuerySample />
+                    </ErrorBoundary>
+                </ClientContextProvider>
+            );
+        });
+        const { getByText } = wrapper;
+        expect( getByText( contentMessage ) ).toBeInTheDocument();
+    });
+});

--- a/src/hooks/customFetch.js
+++ b/src/hooks/customFetch.js
@@ -1,0 +1,16 @@
+import { useState } from "react";
+import { useQuery } from "react-fetching-library";
+
+export const useCustomQuery = ( action ) => {
+    const [error, setError] = useState();
+    const customQuery = useQuery( action );
+
+    if ( !customQuery.loading && customQuery.error ) {
+        setError(customQuery.errorObject);
+    }
+
+    if ( error ) {
+        throw error;
+    }
+    return customQuery;
+};

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -1,0 +1,2 @@
+export { useCustomQuery } from "./customFetch";
+export { useAppPaths } from "./routing";

--- a/src/hooks/samples/UseCustomQuery.jsx
+++ b/src/hooks/samples/UseCustomQuery.jsx
@@ -1,0 +1,26 @@
+import React from "react";
+
+import { useCustomQuery } from "../customFetch";
+import { getExpandCharResults } from "../../services/api/actions";
+import { setAudience, setDictionaryName, setLanguage } from "../../services/api/endpoints";
+
+const UseCustomQuerySample = () => {
+    const audience = 'HealthProfessional';
+    const chr = 'M';
+    const dictionaryName = 'Cancer.gov';
+    const lang = 'en';
+    const baseHost = "http://localhost:3000/api"
+    setAudience(audience);
+    setDictionaryName(dictionaryName);
+    setLanguage(lang);
+    const { loading, payload } = useCustomQuery( `${baseHost}${getExpandCharResults(chr)}` );
+    return (
+        <>
+            {!loading && payload &&
+                <h1>{payload.contentMessage}</h1>
+            }
+        </>
+    );
+};
+
+export default UseCustomQuerySample;

--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,7 @@ import * as serviceWorker from "./serviceWorker";
 import { getProductTestBase } from './utils';
 import { ClientContextProvider } from 'react-fetching-library';
 import { getAxiosClient } from './services/api/axios-client';
+import ErrorBoundary from "./views/ErrorBoundary";
 
 const initialize = ({
   altLanguageDictionaryBasePath = "",
@@ -55,10 +56,12 @@ const initialize = ({
     ReactDOM.hydrate(
       <StateProvider initialState={initialState} reducer={reducer}>
         <AnalyticsProvider analyticsHandler={analyticsHandler}>
-            <ClientContextProvider client={getAxiosClient(initialState)}>
+          <ClientContextProvider client={getAxiosClient(initialState)}>
+            <ErrorBoundary>
               <App />
-            </ClientContextProvider>
-          </AnalyticsProvider>
+            </ErrorBoundary>
+          </ClientContextProvider>
+        </AnalyticsProvider>
       </StateProvider>,
       appRootDOMNode
     );
@@ -67,7 +70,9 @@ const initialize = ({
       <StateProvider initialState={initialState} reducer={reducer} >
         <AnalyticsProvider analyticsHandler={analyticsHandler}>
           <ClientContextProvider client={getAxiosClient(initialState)}>
-            <App />
+            <ErrorBoundary>
+              <App />
+            </ErrorBoundary>
           </ClientContextProvider>
         </AnalyticsProvider>
       </StateProvider>,
@@ -86,7 +91,7 @@ if (process.env.NODE_ENV !== "production") {
   //This is DEV
   const dictSettings = {
     ...appParams,
-    ...integrationTestOverrides,
+    ...integrationTestOverrides
   };
   initialize(dictSettings);
   

--- a/src/services/api/axios-client.js
+++ b/src/services/api/axios-client.js
@@ -6,7 +6,7 @@ import { setAudience, setDictionaryName, setLanguage } from "./endpoints";
 import { requestHostInterceptor } from './requestInterceptors/requestHostInterceptor';
 
 const axiosInstance = axios.create({
-    timeout: 10000,
+    timeout: 15000,
 });
 
 export const getAxiosClient = (initialize) => {

--- a/src/utils/i18n.js
+++ b/src/utils/i18n.js
@@ -15,6 +15,10 @@ export const i18n = {
       en: "No matches were found for the word or phrase you entered. Please check your spelling, and try searching again. You can also type the first few letters of your word or phrase, or click a letter in the alphabet and browse through the list of terms that begin with that letter.",
       es: "No se encontraron resultados para lo que usted busca. Revise si escribió correctamente e inténtelo de nuevo. También puede escribir las primeras letras de la palabra o frase que busca o hacer clic en la letra del alfabeto y revisar la lista de términos que empiezan con esa letra."
     },
+    errorPageText: {
+      en: "An error occurred. Please try again later.",
+      es: "Se produjo un error. Por favor, vuelva a intentar más tarde."
+    },
     search: {
         en: "Search",
         es: "Buscar"

--- a/src/views/Definition/Definition.jsx
+++ b/src/views/Definition/Definition.jsx
@@ -1,8 +1,7 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 import React, { useEffect } from "react";
-import { useQuery } from "react-fetching-library";
-import { useParams } from "react-router";
 import { Helmet } from "react-helmet";
+import { useParams } from "react-router";
 
 import {
   FigureCgovImage,
@@ -13,14 +12,24 @@ import {
   RelatedResourceList
 } from "../../components";
 import { testIds } from "../../constants";
+import { useCustomQuery } from "../../hooks";
 import { getTermDefinition } from "../../services/api/actions";
 import { useStateValue } from "../../store/store.js";
 import { i18n } from "../../utils";
 
 const Definition = () => {
   const { idOrName } = useParams();
-  const { loading, payload, error } = useQuery(getTermDefinition(idOrName));
-  const [{ altLanguageDictionaryBasePath, baseHost, basePath, canonicalHost, dictionaryTitle, language, languageToggleSelector, siteName }] = useStateValue();
+  const { loading, payload } = useCustomQuery(getTermDefinition(idOrName));
+  const [{
+      altLanguageDictionaryBasePath,
+      baseHost,
+      basePath,
+      canonicalHost,
+      dictionaryTitle,
+      language,
+      languageToggleSelector,
+      siteName
+  }] = useStateValue();
 
   useEffect(() => {
     // check if there is an alternate language analog
@@ -58,7 +67,7 @@ const Definition = () => {
     let titleDefinitionText = language === "en" ? "Definition of" : "Definición de";
     let definition = renderMetaDefinition();
 
-    if (altLanguageDictionaryBasePath && 
+    if (altLanguageDictionaryBasePath &&
       payload.otherLanguages &&
       payload.otherLanguages.length > 0
     ) {
@@ -127,6 +136,7 @@ const Definition = () => {
       </>
     );
   };
+
   const renderRelatedResources = () => {
     return (
       <div className="related-resources" data-testid={testIds.MORE_INFORMATION}>
@@ -135,6 +145,7 @@ const Definition = () => {
       </div>
     );
   };
+
   const renderRelatedResourceLinks = () => {
     let headerText = i18n.moreInformation[language];
     if (payload.relatedResources && payload.relatedResources.length > 0) {
@@ -193,10 +204,11 @@ const Definition = () => {
       </>
     );
   };
+
   return (
     <>
       {loading && <Spinner />}
-      {!loading && !error && payload && (
+      {!loading && payload && (
         <>
           {renderHelmet()}
           <h1
@@ -222,4 +234,5 @@ const Definition = () => {
     </>
   );
 };
+
 export default Definition;

--- a/src/views/ErrorBoundary/ErrorBoundary.jsx
+++ b/src/views/ErrorBoundary/ErrorBoundary.jsx
@@ -1,0 +1,24 @@
+import React, { Component } from "react";
+
+import ErrorPage from "./ErrorPage";
+
+class ErrorBoundary extends Component {
+    constructor(props) {
+        super(props);
+        this.state = { hasError: false };
+    }
+
+    static getDerivedStateFromError(error) {
+        // Update state so the next render will show the error page.
+        return { hasError: true };
+    }
+
+    render() {
+        if (this.state.hasError) {
+            return <ErrorPage />;
+        }
+        return this.props.children;
+    }
+}
+
+export default ErrorBoundary;

--- a/src/views/ErrorBoundary/ErrorPage.jsx
+++ b/src/views/ErrorBoundary/ErrorPage.jsx
@@ -1,0 +1,15 @@
+import React from "react";
+
+import { useStateValue } from "../../store/store";
+import { i18n } from "../../utils";
+
+const ErrorPage = () => {
+  const [{ language }] = useStateValue();
+  return (
+    <div className="error-container">
+        <h1>{ i18n.errorPageText[language] }</h1>
+    </div>
+  );
+};
+
+export default ErrorPage;

--- a/src/views/ErrorBoundary/ErrorPage.scss
+++ b/src/views/ErrorBoundary/ErrorPage.scss
@@ -1,0 +1,10 @@
+.error-container h1 {
+  height: 31px;
+  width: 573px;
+  color: #606060;
+  font-family: Montserrat;
+  font-size: 28px;
+  font-weight: bold;
+  letter-spacing: 0;
+  line-height: 30.8px;
+}

--- a/src/views/ErrorBoundary/index.jsx
+++ b/src/views/ErrorBoundary/index.jsx
@@ -1,0 +1,1 @@
+export { default } from "./ErrorBoundary";

--- a/src/views/Home/Home.jsx
+++ b/src/views/Home/Home.jsx
@@ -1,36 +1,29 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 import React, { useEffect, useState } from "react";
-import { useQuery } from "react-fetching-library";
 import { Helmet } from "react-helmet";
 import { useParams, useLocation } from "react-router";
 
 import SearchBox from "../../components/molecules/search-box";
 import { AZListArray, queryType } from "../../constants";
-import { useAppPaths } from "../../hooks/routing";
+import { useAppPaths } from "../../hooks";
 import IntroText from "./IntroText";
-import { getTermCount } from "../../services/api/actions";
-import { updateGlobalValue } from "../../store/actions";
 import { useStateValue } from "../../store/store.js";
 import { NoMatchingResults, TermList } from "../Terms";
-import { formatNumberToThousands, getKeyValueFromQueryString, TokenParser } from "../../utils";
+import { getKeyValueFromQueryString } from "../../utils";
 
 const Home = () => {
-  const [ isIntroTextReplaced, introTextReplaced ] = useState(false);
   const [
       {
           altLanguageDictionaryBasePath,
           basePath,
-          dictionaryIntroText,
           dictionaryTitle ,
           languageToggleSelector
-      },
-      dispatch
+      }
   ] = useStateValue();
   const { HomePath } = useAppPaths();
   const location = useLocation();
   const params = useParams();
   const [ showTermList, setShowTermList ] = useState(false);
-  const termCount = useQuery( getTermCount() );
   const { pathname, search } = location;
   const isExpand =
     pathname.includes(`/${queryType.EXPAND}`) ||
@@ -64,27 +57,11 @@ const Home = () => {
     if (langToggle && altLanguageDictionaryBasePath !== "") {
       initLanguageToggle(langToggle);
     }
-    renderTermListHandler('init');
+    renderTermListHandler();
   }, []);
 
   useEffect( () => {
-    // Todo: This might have to be moved up higher in the chain. Cater to all data necessary
-    //  to load app being fetched first before displaying anything to the user, and fallback
-    //  scenarios should any of these related fetches fail to provide a better user experience.
-    if ( termCount.payload && !isIntroTextReplaced ) {
-        const context = { term_count: formatNumberToThousands( termCount.payload ) };
-        dispatch(
-            updateGlobalValue({
-                field: 'dictionaryIntroText',
-                value: TokenParser.replaceTokens(dictionaryIntroText, context)
-            })
-        );
-        introTextReplaced(true);
-    }
-  }, [termCount.payload, dictionaryIntroText, dispatch, isIntroTextReplaced]);
-
-  useEffect( () => {
-      renderTermListHandler('deps');
+      renderTermListHandler();
   }, [ expandChar, isExpand, isHome, isSearch, searchText, showTermList, matchType ]);
 
   const renderTermListHandler = (caller) => {

--- a/src/views/Home/IntroText.jsx
+++ b/src/views/Home/IntroText.jsx
@@ -1,15 +1,39 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 
 import { testIds } from "../../constants";
-import { useStateValue } from "../../store/store.js";
+import { useCustomQuery } from "../../hooks";
+import { getTermCount } from "../../services/api/actions";
+import { updateGlobalValue } from "../../store/actions";
+import { useStateValue } from "../../store/store";
+import { formatNumberToThousands, TokenParser } from "../../utils";
 
 const IntroText = () => {
-    const [{ dictionaryIntroText }] = useStateValue();
+    const [ isIntroTextReplaced, introTextReplaced ] = useState(false);
+    const [{ dictionaryIntroText }, dispatch] = useStateValue();
+    const termCount = useCustomQuery( getTermCount() );
+
+    useEffect( () => {
+        // Todo: This might have to be moved up higher in the chain. Cater to all data necessary
+        //  to load app being fetched first before displaying anything to the user, and fallback
+        //  scenarios should any of these related fetches fail to provide a better user experience.
+        if ( termCount.payload && !isIntroTextReplaced ) {
+            const context = { term_count: formatNumberToThousands( termCount.payload ) };
+            dispatch(
+                updateGlobalValue({
+                    field: 'dictionaryIntroText',
+                    value: TokenParser.replaceTokens(dictionaryIntroText, context)
+                })
+            );
+            introTextReplaced(true);
+        }
+    }, [termCount.payload, dictionaryIntroText, dispatch, isIntroTextReplaced]);
 
     return (
-        <div data-testid={testIds.INTRO_TEXT}
-             dangerouslySetInnerHTML={{__html: dictionaryIntroText}}>
-        </div>
+        <>
+            <div data-testid={testIds.INTRO_TEXT}
+                 dangerouslySetInnerHTML={{__html: dictionaryIntroText}}>
+            </div>
+        </>
     );
 };
 

--- a/src/views/Home/index.jsx
+++ b/src/views/Home/index.jsx
@@ -1,1 +1,1 @@
-export { default } from './Home';
+export { default } from "./Home";

--- a/src/views/Terms/Term.jsx
+++ b/src/views/Terms/Term.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import { Link } from "react-router-dom";
 
 import { Pronunciation } from "../../components";
-import { useAppPaths } from "../../hooks/routing";
+import { useAppPaths } from "../../hooks";
 import { useStateValue } from "../../store/store";
 import { testIds } from "../../constants";
 

--- a/src/views/Terms/TermList.jsx
+++ b/src/views/Terms/TermList.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import { useQuery } from "react-fetching-library";
 
 import Spinner from "../../components/atomic/spinner";
 import { queryType } from "../../constants";
+import { useCustomQuery } from "../../hooks";
 import NoMatchingResults from "./NoMatchingResults";
 import { getExpandCharResults, getSearchResults } from "../../services/api/actions";
 import { useStateValue } from "../../store/store";
@@ -13,13 +13,13 @@ const TermList = ({ matchType, query, type }) => {
     const queryAction = type === queryType.SEARCH
         ? getSearchResults(query, matchType)
         : getExpandCharResults(query);
-    const { loading, payload, error } = useQuery( queryAction );
+    const { loading, payload } = useCustomQuery( queryAction );
     const [{ language }] = useStateValue();
-    // console.log('TermList:', type, query, matchType);
+
     return (
         <>
             { loading && <Spinner /> }
-            { !loading && !error && payload &&
+            { !loading && payload &&
                 <div className="dictionary-list-container results" data-dict-type="term">
                     { payload.results && payload.results.length > 0
                         ?

--- a/support/mock-data/Terms/Cancer.gov/Patient/en/44058__metastatic-untranslated.json
+++ b/support/mock-data/Terms/Cancer.gov/Patient/en/44058__metastatic-untranslated.json
@@ -1,0 +1,55 @@
+{
+  "termId": 44058,
+  "language": "en",
+  "dictionary": "Cancer.gov",
+  "audience": "Patient",
+  "termName": "metastatic-untranslated",
+  "firstLetter": "m",
+  "prettyUrlName": "metastatic-untranslated",
+  "pronunciation": {
+    "key": "(meh-tuh-STA-tik)",
+    "audio": "https://nci-media-dev.cancer.gov/pdq/media/audio/704104.mp3"
+  },
+  "definition": {
+    "html": "Having to do\n          with metastasis, which is the spread of cancer from the\n          primary site (place where it started) to other places in\n          the body.",
+    "text": "Having to do\n          with metastasis, which is the spread of cancer from the\n          primary site (place where it started) to other places in\n          the body."
+  },
+  "relatedResources": [
+    {
+      "Url": "https://www.cancer.gov/types/metastatic-cancer",
+      "Type": "External",
+      "Text": "Metastatic Cancer"
+    }
+  ],
+  "media": [
+    {
+      "Type": "Image",
+      "ImageSources": [
+        {
+          "Size": "original",
+          "Src": "https://nci-media-dev.cancer.gov/pdq/media/images/764135.jpg"
+        },
+        {
+          "Size": "571",
+          "Src": "https://nci-media-dev.cancer.gov/pdq/media/images/764135-571.jpg"
+        },
+        {
+          "Size": "750",
+          "Src": "https://nci-media-dev.cancer.gov/pdq/media/images/764135-750.jpg"
+        }
+      ],
+      "Ref": "CDR0000764135",
+      "Alt": "Metastasis; drawing shows primary cancer that has spread from the colon to other parts of the body (the liver and the lung). An inset shows cancer cells spreading from the primary cancer, through the blood and lymph system, to another part of the body where a metastatic tumor has formed.",
+      "Caption": "Metastasis. In metastasis, cancer cells break away from where they first formed (primary cancer), travel through the blood or lymph system, and form new tumors (metastatic tumors) in other parts of the body. The metastatic tumor is the same type of cancer as the primary tumor. "
+    },
+    {
+      "Type": "Video",
+      "Hosting": "youtube",
+      "Ref": "CDR0000787719",
+      "UniqueId": "fQwar_-QdiQ",
+      "Template": "Video75NoTitle",
+      "Title": "Metastasis: How Cancer Spreads",
+      "Caption": "Many cancer deaths are caused when cancer moves from the original tumor and spreads to other tissues and organs. This is called metastatic cancer. This animation shows how cancer cells travel from the place in the body where they first formed to other parts of the body."
+    }
+  ]
+}

--- a/support/src/setupProxy.js
+++ b/support/src/setupProxy.js
@@ -46,27 +46,12 @@ const getResultsByQueryType = async ( req, res, next ) => {
                 res.sendFile(mockFile);
             })
             .catch( err => {
-                const resObject = {
-                    meta: {
-                        totalResults: 0,
-                        from: 0
-                    },
-                    results: [],
-                    links: null
-                };
-                console.error(err);
-                if ( err.code === 'ENOENT') {
-                    console.log(
-                        'Create file with payload in path specified above to return a response with results. ' + '\n' +
-                        'Returning response with no results for request.',
-                        resObject
-                    );
-                }
-                res.send(resObject);
+                // const mockResponse = mockNoResultsAPI( err );
+                res.send( mockNoResultsAPI( err ) );
             });
     } catch (err) {
         console.error(err);
-        res.status(404).end();
+        res.send( mockNoResultsAPI( err ) );
     }
   };
 
@@ -128,6 +113,26 @@ const getTermByIdOrPrettyUrl = async (req, res, next) => {
     console.error(err);
     res.status(404).end();
   }
+};
+
+const mockNoResultsAPI = (err) => {
+    const resObject = {
+        meta: {
+            totalResults: 0,
+            from: 0
+        },
+        results: [],
+        links: null
+    };
+    if ( err && err.code === 'ENOENT') {
+        console.error(err);
+        console.log(
+            'Create file with payload in path specified above to return a response with results. ' + '\n' +
+            'Returning response with no results for request.',
+            resObject
+        );
+    }
+    return resObject;
 };
 
 /**


### PR DESCRIPTION
Closes #110

* Added integration tests for API error page
* Fixed failing integration tests
* Update customFetch to add actual error message
* Update to setUpProxy to return results for not found directory rather than 404
* Added missing piece from previous rebase conflict
* Moved termCount call to IntroText
* Fixed integration tests for API failure, Site-wide language toggle, and added missing initialize params for test
* Updated and added mock file for MetaTagInUnrelatedApp.feature
* Removed spinner for IntroText component
* Bumped up axios timeout, added unit tests for customFetch