### PR TITLE
(#30) Add metadata to definition pages

### DIFF
--- a/cypress/integration/MetaTagsEnglishTerm.feature
+++ b/cypress/integration/MetaTagsEnglishTerm.feature
@@ -1,0 +1,42 @@
+Feature: As a user, I want metadata on the page, so that I can share the web page to social media services correctly
+
+    Background:
+        Given "language" is set to "en"
+        And "dictionaryTitle" is set to "NCI Dictionary of Cancer Terms"
+        And "dictionaryName" is set to "Cancer.gov"
+        And "baseHost" is set to "http://localhost:3000"
+        And "canonicalHost" is set to "https://www.cancer.gov"
+        And "altLanguageDictionaryBasePath" is set to "/espanol/publicaciones/diccionario"
+        And "siteName" is set to "National Cancer Institute"
+
+    Scenario: View basic term metadata
+        Given the user is viewing the definition with the pretty url "metastatic"
+        Then the title tag should be "Definition of metastatic - NCI Dictionary of Cancer Terms - National Cancer Institute"
+        And the page contains meta tags with the following properties
+            | property | content                                                   |
+            | og:title | Definition of metastatic - NCI Dictionary of Cancer Terms |
+            | og:url   | http://localhost:3000/def/metastatic                      |
+        And there is a canonical link with the href "https://www.cancer.gov/def/metastatic"
+        And there are alternate links with the following
+            | href                                                                    | hreflang |
+            | http://localhost:3000/def/metastatic                                    | en       |
+            | http://localhost:3000/espanol/publicaciones/diccionario/def/metastasico | es       |
+
+
+    Scenario: Term meta descriptions over two sentences truncated after two sentences
+        Given the user is viewing the definition with the pretty url "hpv"
+        Then the page contains meta tags with the following properties
+            | property       | content                                                                                                                                                                               |
+            | og:description | A type of virus that can cause abnormal tissue growth (for example, warts) and other changes to cells. Infection for a long time with certain types of HPV can cause cervical cancer. |
+        And the page contains meta tags with the following names
+            | name        | content                                                                                                                                                                               |
+            | description | A type of virus that can cause abnormal tissue growth (for example, warts) and other changes to cells. Infection for a long time with certain types of HPV can cause cervical cancer. |
+
+    Scenario: Term meta descriptions UNDER two sentences are displayed in full
+        Given the user is viewing the definition with the pretty url "m-protein"
+        And the page contains meta tags with the following names
+            | name        | content                                                                                                                                                                   |
+            | description | An antibody found in unusually large amounts in the blood or urine of people with multiple myeloma and other types of plasma cell tumors. Also called monoclonal protein. |
+        Then the page contains meta tags with the following properties
+            | property       | content                                                                                                                                                                   |
+            | og:description | An antibody found in unusually large amounts in the blood or urine of people with multiple myeloma and other types of plasma cell tumors. Also called monoclonal protein. |

--- a/cypress/integration/MetaTagsGeneticTerm.feature
+++ b/cypress/integration/MetaTagsGeneticTerm.feature
@@ -1,0 +1,19 @@
+Feature: Feature: As a user, I want metadata on the Genetic dictionary term page, so that I can share the web page to social media services correctly
+
+    Background:
+        Given "language" is set to "en"
+        And "audience" is set to "HealthProfessional"
+        And "dictionaryName" is set to "Genetics"
+        And "dictionaryTitle" is set to "NCI Dictionary of Genetics Terms"
+        And "baseHost" is set to "http://localhost:3000"
+        And "canonicalHost" is set to "https://www.cancer.gov"
+        And "siteName" is set to "National Cancer Institute"
+
+    Scenario: View basic term metadata Genetics dictionary
+        Given the user is viewing the definition with the pretty url "acrochordon"
+        Then the title tag should be "Definition of acrochordon - NCI Dictionary of Genetics Terms - National Cancer Institute"
+        And the page contains meta tags with the following properties
+            | property | content                                                      |
+            | og:title | Definition of acrochordon - NCI Dictionary of Genetics Terms |
+            | og:url   | http://localhost:3000/def/acrochordon                        |
+        And there is a canonical link with the href "https://www.cancer.gov/def/acrochordon"

--- a/cypress/integration/MetaTagsInUntranslatedApp.feature
+++ b/cypress/integration/MetaTagsInUntranslatedApp.feature
@@ -1,0 +1,14 @@
+Feature: As a user, I want metadata on the page, so that I can share the web page to social media services correctly
+
+    Background:
+        Given "language" is set to "en"
+        And "dictionaryTitle" is set to "NCI Dictionary of Cancer Terms"
+        And "dictionaryName" is set to "Cancer.gov"
+        And "baseHost" is set to "http://localhost:3000"
+        And "canonicalHost" is set to "https://www.cancer.gov"
+        And "siteName" is set to "National Cancer Institute"
+
+    Scenario: View page works when there translated defs in an untranslated app
+        Given the user is viewing the definition with the pretty url "metastatic"
+        Then the page title is "metastatic"
+        And there are no alternate links

--- a/cypress/integration/MetaTagsOnSpanishTerm.feature
+++ b/cypress/integration/MetaTagsOnSpanishTerm.feature
@@ -1,0 +1,24 @@
+Feature: As a user, I want metadata on the Spanish definition page, so that I can share the web page to social media services correctly
+
+    Background:
+        Given "language" is set to "es"
+        And "siteName" is set to "Instituto Nacional del Cáncer"
+        And "dictionaryTitle" is set to "Diccionario de cáncer"
+        And "dictionaryName" is set to "Cancer.gov"
+        And "baseHost" is set to "http://localhost:3000"
+        And "canonicalHost" is set to "https://www.cancer.gov"
+        And "altLanguageDictionaryBasePath" is set to "/publications/dictionaries/cancer-terms"
+        And "siteName" is set to "Instituto Nacional del Cáncer"
+
+    Scenario: View basic term metadata in Spanish
+        Given the user is viewing the definition with the pretty url "metastasico"
+        Then the title tag should be "Definición de metastásico - Diccionario de cáncer - Instituto Nacional del Cáncer"
+        And the page contains meta tags with the following properties
+            | property | content                                           |
+            | og:title | Definición de metastásico - Diccionario de cáncer |
+            | og:url   | http://localhost:3000/def/metastasico             |
+        And there is a canonical link with the href "https://www.cancer.gov/def/metastasico"
+        And there are alternate links with the following
+            | href                                                                        | hreflang |
+            | http://localhost:3000/publications/dictionaries/cancer-terms/def/metastatic | en       |
+            | http://localhost:3000/def/metastasico                                       | es       |

--- a/cypress/integration/SitewideLanguageToggle.feature
+++ b/cypress/integration/SitewideLanguageToggle.feature
@@ -1,4 +1,7 @@
 Feature: Sitewide Language Toggle
+    Background:
+        Given "language" is set to "en"
+        And "altLanguageDictionaryBasePath" is set to "/espanol/publicaciones/diccionario"
 
     Scenario: Toggle for a definition points to a translation
         Given the user is viewing the definition with the pretty url "metastatic"

--- a/cypress/integration/common/MetaTags.js
+++ b/cypress/integration/common/MetaTags.js
@@ -1,0 +1,60 @@
+/// <reference types="Cypress" />
+import { Then } from 'cypress-cucumber-preprocessor/steps';
+
+Then('the page contains meta tags with the following names', dataTable => {
+  for (const { name, content } of dataTable.hashes()) {
+
+    const locator = `meta[name='${name}']`;
+      //find element, ensure it has attribute content 
+    //compare content's value with expected one
+    cy.get(locator).should('have.attr', 'content').and('be.eq', content);
+  }
+});
+
+Then('the page contains meta tags with the following properties', dataTable => {
+  for (const { property, content } of dataTable.hashes()) {
+    const locator = `META[property='${property}']`;
+    //find element, ensure it has attribute content 
+    //compare content's value with expected one
+    cy.get(locator).should('have.attr', 'content').and('be.eq', content);
+  }
+});
+
+Then('there is a canonical link with the href {string}', (href) => {
+  cy.get("link[rel='canonical']")
+    //verify there is only one link
+    .should('have.length', 1)
+    //verify it has attribute 'href
+    .and('have.attr', 'href')
+    //href attr contains expected url
+    .and('be.eq', href);
+});
+
+Then('the title tag should be {string}', (expectedTitle) => {
+ 
+   cy.get('head>title').invoke('text').should('be.eq',expectedTitle);
+    // console.log(title)
+    // //assert title text is equal to expected
+    // expect(title).to.eq(expectedTitle)
+  // });
+
+});
+
+Then('there are alternate links with the following', dataTable => {
+  const locator = "[rel='alternate']";
+  //convert data table into the object of type 
+  //{ header 1: row 1 col 1, header 2: row 1 col 2 },
+  // { header 1: row 2 col 1, header 2: row 2 col 2 },
+  for (const { href, hreflang } of dataTable.hashes()) {
+    //find element with concatenated attributes (rel=alternate and href=foo)
+    cy.get(`${locator}[href='${href}']`)
+      //assert it has the hreflang attr
+      .should('have.attr', 'hreflang')
+      //hreflang value is matching expected
+      .and('be.eq', hreflang);
+  }
+});
+
+Then('there are no alternate links', () => {
+  cy.get("[rel='alternate']").should('not.exist');
+})

--- a/cypress/integration/common/beforeEach.js
+++ b/cypress/integration/common/beforeEach.js
@@ -9,12 +9,16 @@ beforeEach(() => {
     // to development defaults does not break a bunch of texts.
     win.INT_TEST_APP_PARAMS = { 
       audience: 'Patient',
-      basePath: '/',
+      basePath: '',
+      baseHost: 'http://localhost:3000',
       dictionaryEndpoint: "/api",
       dictionaryName: 'Cancer.gov',
       dictionaryTitle: 'NCI Dictionary of Cancer Terms',
-      dictionaryIntoText: 'Intro Text',
-      language: 'en'
+      dictionaryIntroText: 'Intro Text',
+      language: 'en',
+      canonicalHost: 'https://www.cancer.gov',
+      altLanguageDictionaryBasePath: "",
+      siteName: 'National Cancer Institute'
     }
     console.log(win.INT_TEST_APP_PARAMS)
   });

--- a/public/index.html
+++ b/public/index.html
@@ -38,7 +38,9 @@
           },
           appId: "@@/TERMS_DICTIONARY",
           audience: "Patient",
+          baseHost: "http://localhost:3000",
           basePath: "",
+          canonicalHost: "https://www.cancer.gov",
           dictionaryEndpoint: "https://webapis-dev.cancer.gov/glossary/v1/",
           dictionaryIntroText:
             "<p>The NCI Dictionary of Cancer Terms features <strong>{{term_count}}</strong> terms related to cancer and medicine.</p>" +
@@ -46,7 +48,8 @@
           dictionaryName: "Cancer.gov",
           dictionaryTitle: "NCI Dictionary of Cancer Terms",
           language: "en",
-          searchBoxTitle: "Search NCI's Dictionary of Cancer Terms"
+          searchBoxTitle: "Search NCI's Dictionary of Cancer Terms",
+          siteName: "National Cancer Institute"
         },
         {
           altLanguageDictionaryBasePath: "/publications/dictionaries/cancer-terms",
@@ -55,7 +58,9 @@
           },
           appId: "@@/TERMS_DICTIONARY_SPANISH",
           audience: "Patient",
+          baseHost: "http://localhost:3000",
           basePath: "",
+          canonicalHost: "https://www.cancer.gov",
           dictionaryEndpoint: "https://webapis-dev.cancer.gov/glossary/v1/",
           dictionaryIntroText:
             "<p>El diccionario de cáncer del NCI contiene <strong>{{term_count}}</strong> términos relacionados con el cáncer y la medicina.</p>" +
@@ -63,7 +68,8 @@
           dictionaryName: "Cancer.gov",
           dictionaryTitle: "Diccionario de cáncer",
           language: "es",
-          searchBoxTitle: "Busca diccionario de cáncer"
+          searchBoxTitle: "Busca diccionario de cáncer",
+          siteName: "Instituto Nacional del Cáncer"
         },
         {
           analyticsHandler: data => {
@@ -71,14 +77,17 @@
           },
           appId: "@@/GENETICS_DICTIONARY",
           audience: "HealthProfessional",
+          baseHost: "http://localhost:3000",
           basePath: "",
+          canonicalBase: "https://www.cancer.gov/publications/dictionaries/",
           dictionaryEndpoint: "https://webapis-dev.cancer.gov/glossary/v1/",
           dictionaryIntroText:
             "<p>The NCI Dictionary of Genetics Terms contains technical definitions for more than {{term_count}} terms related to genetics. These definitions were developed by the <a title=\"Follow link\" class=\"external-link\" href=\"/publications/pdq/editorial-boards/genetics\" rel=\"nofollow\"> PDQ® Cancer Genetics Editorial Board</a> to support the evidence-based, peer-reviewed <a title=\"Follow link\" class=\"external-link\" href=\"/publications/pdq/information-summaries/genetics\" rel=\"nofollow\"> PDQ cancer genetics information summaries</a>.</p>",
           dictionaryName: "Genetics",
           dictionaryTitle: "NCI Dictionary of Genetics Terms",
           language: "en",
-          searchBoxTitle: "Search NCI's Dictionary of Genetics Terms"
+          searchBoxTitle: "Search NCI's Dictionary of Genetics Terms",
+          siteName: "National Cancer Institute"
         },
         {
           analyticsHandler: data => {
@@ -86,14 +95,17 @@
           },
           appId: "@@/GENETICS_DICTIONARY_SPANISH",
           audience: "HealthProfessional",
+          baseHost: "http://localhost:3000",
           basePath: "",
+          canonicalHost: "https://www.cancer.gov",
           dictionaryEndpoint: "https://webapis-dev.cancer.gov/glossary/v1/",
           dictionaryIntroText:
             "El diccionario de genética del NCI contiene mas de {{term_count}} términos relacionados con genética.",
           dictionaryName: "Genetics",
           dictionaryTitle: "Diccionario de genética",
           language: "es",
-          searchBoxTitle: "Busca diccionario de genética"
+          searchBoxTitle: "Busca diccionario de genética",
+          siteName: "Instituto Nacional del Cáncer"
         }
       ];
 

--- a/src/index.js
+++ b/src/index.js
@@ -17,7 +17,9 @@ const initialize = ({
   appId = "@@/DEFAULT_DICTIONARY",
   analyticsHandler = data => {},
   audience = 'Patient',
+  baseHost = 'http://localhost:3000',
   basePath = '/',
+  canonicalHost = 'https://www.cancer.gov',
   dictionaryEndpoint = "https://webapis-dev.cancer.gov/glossary/v1/",
   dictionaryName = "Cancer.gov",
   dictionaryIntroText = "The NCI Dictionary of Cancer Terms features {{term_count}} terms related to cancer and medicine",
@@ -25,7 +27,8 @@ const initialize = ({
   language = "en", // en|es (English|Spanish)
   languageToggleSelector = '#LangList1 a',
   rootId = "NCI-app-root",
-  searchBoxTitle = "Search NCI's Dictionary of Cancer Terms"
+  searchBoxTitle = "Search NCI's Dictionary of Cancer Terms",
+  siteName = "National Cancer Institute"
 } = {}) => {
   const appRootDOMNode = document.getElementById(rootId);
   const isRehydrating = appRootDOMNode.getAttribute("data-isRehydrating");
@@ -35,14 +38,17 @@ const initialize = ({
     altLanguageDictionaryBasePath,
     appId,
     audience,
+    baseHost,
     basePath,
+    canonicalHost,
     dictionaryEndpoint,
     dictionaryName,
     dictionaryIntroText,
     dictionaryTitle,
     language,
     languageToggleSelector,
-    searchBoxTitle
+    searchBoxTitle,
+    siteName
   };
 
   if (isRehydrating) {


### PR DESCRIPTION
* Add fields needed for metadata setup to config
* Update configs for four dictionaries to include new fields
* Add metadata changes through helmet to definition rendering

* Added integration tests for meta tags
* Fixed LanguageToggle background