### PR TITLE
(#121) Update term lists to use pretty URL name

### DIFF
--- a/cypress/integration/EnglishKeywordSearch.feature
+++ b/cypress/integration/EnglishKeywordSearch.feature
@@ -9,6 +9,12 @@ Feature: As a user, I would like to be able to enter keywords and have the optio
         Then the URL contains "/search"
         And search results page displays results title "# results found for: " "<keyword>"
         And each result in the results listing appears as a link to the term's page
+        And the term links have the following hrefs
+            | term               | href                     |
+            | meta-analysis      | /def/meta-analysis       |
+            | metabolic          | /def/44056               |
+            | metabolic acidosis | /def/metabolic-acidosis  |
+            | metabolic disorder | /def/44055               |
         And "Starts with" option is selected
         And search bar contains the "<keyword>" that user entered
 
@@ -26,6 +32,12 @@ Feature: As a user, I would like to be able to enter keywords and have the optio
         Then the URL contains "/search"
         And search results page displays results title "# results found for: " "<keyword>"
         And each result in the results listing appears as a link to the term's page
+        And the term links have the following hrefs
+            | term                          | href                     |
+            | aerobic metabolism            | /def/aerobic-metabolism  |
+            | agnogenic myeloid metaplasia  | /def/306486              |
+            | antimetabolite                | /def/antimetabolite      |
+            | bone marrow metastasis        | /def/45623               |
         And "Contains" option is selected
         And search bar contains the "<keyword>" that user entered
 

--- a/cypress/integration/SpanishKeywordSearch.feature
+++ b/cypress/integration/SpanishKeywordSearch.feature
@@ -14,6 +14,12 @@ Feature: As a user, I would like to be able to enter keywords on Spanish cancer 
         Then the URL contains "/buscar"
         And search results page displays results title "# resultados de: " "<keyword>"
         And each result in the results listing appears as a link to the term's page
+        And the term links have the following hrefs
+            | term                 | href                       |
+            | metabólico           | /def/metabolico            |
+            | metabolismo          | /def/46173                 |
+            | metabolismo aeróbico | /def/metabolismo-aerobico  |
+            | metabolismo celular  | /def/44126                 |
         And "Empieza con" option is selected
         And search bar contains the "<keyword>" that user entered
 
@@ -32,6 +38,12 @@ Feature: As a user, I would like to be able to enter keywords on Spanish cancer 
         Then the URL contains "/buscar"
         And search results page displays results title "# resultados de: " "<keyword>"
         And each result in the results listing appears as a link to the term's page
+        And the term links have the following hrefs
+            | term                 | href                 |
+            | acidosis metabólica  | /def/44332           |
+            | antimetabolito       | /def/antimetabolito  |
+            | azoximetano          | /def/367457          |
+            | beclometasona        | /def/beclometasona   |
         And "Contiene" option is selected
         And search bar contains the "<keyword>" that user entered
 

--- a/cypress/integration/ViewTermsByLetter.feature
+++ b/cypress/integration/ViewTermsByLetter.feature
@@ -13,6 +13,13 @@ Feature: View Terms by letter
     And each result in the results listing appears as a link to the term's page
     And the audio icon and the pronunciation appear beside the term on the same line as the link
     And each result displays its full definition below the link for the term
+    And the term links have the following hrefs
+      | term           | href          |
+      | A33            | /def/a33      |
+      | A6             | /def/658765   |
+      | AAP            | /def/aap      |
+      | AAT deficiency | /def/797047   |
+      | abarelix       | /def/abarelix |
 
   Scenario: Results /expand page metadata
     Given the user is viewing a results page based on clicking a letter like "A" in the dictionary

--- a/cypress/integration/ViewTermsByLetterSpanish.feature
+++ b/cypress/integration/ViewTermsByLetterSpanish.feature
@@ -14,6 +14,13 @@ Feature: View Terms by letter Spanish
     Then search results page displays results title "# resultados de: A"
     And each result in the results listing appears as a link to the term's page
     And each result displays its full definition below the link for the term
+    And the term links have the following hrefs
+      | term           | href          |
+      | A33            | /def/46722    |
+      | A6             | /def/a6       |
+      | AAF-EE         | /def/592940   |
+      | AAP            | /def/aap      |
+      | abarelix       | /def/abarelix |
 
   Scenario: Results /ampliar page metadata
     Given the user is viewing a results page based on clicking a letter like "A" in the dictionary

--- a/cypress/integration/common/index.js
+++ b/cypress/integration/common/index.js
@@ -346,6 +346,19 @@ And('each result displays its full definition below the link for the term', () =
   expect(cy.get(`dd[data-testid='${testIds.TERM_ITEM_DESCRIPTION}']`)).to.exist;
 });
 
+And('the term links have the following hrefs', dataTable => {
+  cy.document().then(doc => {
+    const terms = doc.querySelectorAll('dfn a');
+    for (const { term, href } of dataTable.hashes()) {
+      terms.forEach(singleTerm => {
+        if (singleTerm.innerText === term) 
+          expect(singleTerm.href).to.eq(`${baseURL}${href}`);
+        
+      });
+    }
+  })
+});
+
 
 /*
     ----------------------------------------
@@ -426,7 +439,7 @@ cy.get('#LangList1 a').should('have.attr','href').and('to.be.eq',urlPath);
 
 /*
     ----------------------------------------
-       API Error Page
+      API Error Page
     ----------------------------------------
 */
 

--- a/src/views/Terms/Term.jsx
+++ b/src/views/Terms/Term.jsx
@@ -9,14 +9,14 @@ import { testIds } from "../../constants";
 const Term = ({ payload }) => {
   const { DefinitionPath } = useAppPaths();
   const [{ language }] = useStateValue();
-  const { definition, termId, termName, pronunciation } = payload;
+  const { definition, termId, termName, prettyUrlName, pronunciation } = payload;
 
   
   return (
     <div>
       <dt>
         <dfn data-cdr-id={termId}>
-          <Link to={DefinitionPath({ idOrName: termId })}>{termName}</Link>
+          <Link to={DefinitionPath({ idOrName: prettyUrlName ? prettyUrlName : termId })}>{termName}</Link>
         </dfn>
       </dt>
       {pronunciation && (

--- a/src/views/Terms/__tests__/Term.test.js
+++ b/src/views/Terms/__tests__/Term.test.js
@@ -5,79 +5,145 @@ import { MemoryRouter, useLocation } from "react-router";
 import { testIds } from "../../../constants";
 import { Term } from "../index";
 import { useStateValue } from "../../../store/store";
-import fixtures from "../../../utils/fixtures";
 
 jest.mock("../../../store/store");
 
 let wrapper;
-const query = "A";
-const queryFile = `${query}.json`;
-const { getFixture } = fixtures;
-const fixturePath = `/Terms/expand/Cancer.gov/Patient`;
 
 describe('Term component rendered with English', () => {
     let location;
     const language = "en";
     const searchBoxTitle = "Search NCI's Dictionary of Cancer Terms";
-    // Get first result from mock file A.json
-    const term = getFixture(`${fixturePath}/${language}/${queryFile}`).results[0];
 
-    function TermWithLocation() {
+    // Set up two mock terms
+    const testTerms = [
+        [
+            "pretty URL name",
+            {
+                termId: 46722,
+                language: "en",
+                dictionary: "Cancer.gov",
+                audience: "Patient",
+                termName: "A33",
+                firstLetter: "a",
+                prettyUrlName: "a33",
+                pronunciation: null,
+                definition: {
+                    html: "A type of monoclonal antibody used in cancer detection or therapy. Monoclonal antibodies are laboratory-produced substances that can locate and bind to cancer cells.",
+                    text: "A type of monoclonal antibody used in cancer detection or therapy. Monoclonal antibodies are laboratory-produced substances that can locate and bind to cancer cells."
+                },
+                relatedResources: [],
+                media: []
+            },
+            {
+                pathname: `/def/a33`,
+                search: '',
+                hash: '',
+                state: null,
+                key: expect.any(String)
+            }
+        ],
+        [
+            "term ID only",
+            {
+                termId: 658765,
+                language: "en",
+                dictionary: "Cancer.gov",
+                audience: "Patient",
+                termName: "A6",
+                firstLetter: "a",
+                prettyUrlName: null,
+                pronunciation: null,
+                definition: {
+                    html: "A substance being studied in the treatment of cancer. A6 is a small piece of a protein called urokinase (an enzyme that dissolves blood clots or prevents them from forming). It is a type of antiangiogenesis agent and a type of antimetastatic agent. Also called urokinase plasminogen activator (uPA)-derived peptide A6.",
+                    text: "A substance being studied in the treatment of cancer. A6 is a small piece of a protein called urokinase (an enzyme that dissolves blood clots or prevents them from forming). It is a type of antiangiogenesis agent and a type of antimetastatic agent. Also called urokinase plasminogen activator (uPA)-derived peptide A6."
+                },
+                relatedResources: [],
+                media: []
+            },
+            {
+                pathname: `/def/658765`,
+                search: '',
+                hash: '',
+                state: null,
+                key: expect.any(String)
+            }
+        ]
+    ];
+
+    function TermWithLocation({term}) {
         location = useLocation();
         return <Term payload={term} />;
-    }
-
-    beforeEach(async () => {
-        const dictionaryName = "Cancer.gov";
-        const dictionaryTitle = "NCI Dictionary of Cancer Terms";
-
-        useStateValue.mockReturnValue([
-            {
-                appId: "mockAppId",
-                basePath: "/",
-                dictionaryName,
-                dictionaryTitle,
-                language,
-                searchBoxTitle
-            }
-        ]);
-
-        await act( async () => {
-            wrapper = render(
-                <MemoryRouter initialEntries={["/"]}>
-                    <TermWithLocation />
-                </MemoryRouter>
-            );
-        });
-    });
+    };
 
     afterEach(() => {
         cleanup();
     });
 
-    test('Check term title exists as link, click on link and confirm correct location', () => {
-        const expectedLocationObject = {
-            pathname: `/def/${term.termId}`,
-            search: '',
-            hash: '',
-            state: null,
-            key: expect.any(String)
-        };
-        const { getByRole } = wrapper;
-        // Get term title link
-        const termTitleLink = getByRole('link');
-        // Expect term title link text to match term name
-        expect(termTitleLink.textContent).toBe(term.termName);
-        // Click on term title link
-        fireEvent.click(termTitleLink);
-        // Expect to navigate to definition page for term
-        expect(location).toMatchObject(expectedLocationObject);
-    });
+    test.each(testTerms)
+        ('Check term title exists as link, click on link and confirm correct location when term has %s',
+        async (termType, termObject, expectedLocationObject) => {
+            const dictionaryName = "Cancer.gov";
+            const dictionaryTitle = "NCI Dictionary of Cancer Terms";
+
+            useStateValue.mockReturnValue([
+                {
+                    appId: "mockAppId",
+                    basePath: "/",
+                    dictionaryName,
+                    dictionaryTitle,
+                    language,
+                    searchBoxTitle
+                }
+            ]);
+
+            await act( async () => {
+                wrapper = render(
+                    <MemoryRouter initialEntries={["/"]}>
+                        <TermWithLocation term={termObject}/>
+                    </MemoryRouter>
+                );
+            });
+            
+            const { getByRole } = wrapper;
+            // Get term title link
+            const termTitleLink = getByRole('link');
+            // Expect term title link text to match term name
+            expect(termTitleLink.textContent).toBe(termObject.termName);
+            // Click on term title link
+            fireEvent.click(termTitleLink);
+            // Expect to navigate to definition page for term
+            expect(location).toMatchObject(expectedLocationObject);
+        });
 
     // Add term description test
-    test('Term description is displayed', () => {
-       const { getByTestId } = wrapper;
-       expect(getByTestId(testIds.TERM_ITEM_DESCRIPTION)).toBeInTheDocument();
+    test.each(testTerms)
+        ('Term description is displayed for term with %s',
+        async (termType, termObject, expectedLocationObject) => {
+        const dictionaryName = "Cancer.gov";
+            const dictionaryTitle = "NCI Dictionary of Cancer Terms";
+
+            useStateValue.mockReturnValue([
+                {
+                    appId: "mockAppId",
+                    basePath: "/",
+                    dictionaryName,
+                    dictionaryTitle,
+                    language,
+                    searchBoxTitle
+                }
+            ]);
+
+            await act( async () => {
+                wrapper = render(
+                    <MemoryRouter initialEntries={["/"]}>
+                        <TermWithLocation term={termObject}/>
+                    </MemoryRouter>
+                );
+            });
+            
+        const { getByTestId } = wrapper;
+        expect(getByTestId(testIds.TERM_ITEM_DESCRIPTION)).toBeInTheDocument();
     });
 
 });

--- a/support/mock-data/Terms/Cancer.gov/Patient/en/644322__natural-killer-cell-large-granular-lymphocyte-leukemia.json
+++ b/support/mock-data/Terms/Cancer.gov/Patient/en/644322__natural-killer-cell-large-granular-lymphocyte-leukemia.json
@@ -1,0 +1,26 @@
+{
+    "termId": 644322,
+    "language": "en",
+    "dictionary": "Cancer.gov",
+    "audience": "Patient",
+    "termName": "natural killer-cell large granular lymphocyte leukemia",
+    "firstLetter": "n",
+    "prettyUrlName": null,
+    "pronunciation": {
+        "key": "(NA-chuh-rul KIH-ler-sel larj GRAN-yoo-lur LIM-foh-site loo-KEE-mee-uh)",
+        "audio": "https://nci-media-dev.cancer.gov/pdq/media/audio/726072.mp3"
+    },
+    "definition": {
+        "html": "A type of leukemia in which large natural killer (NK) cells (a type of white blood cell) that contain granules (small particles) are found in the blood. It is a chronic disease that may last for a long time and get worse. Also called NK-LGL leukemia and NK-LGLL.",
+        "text": "A type of leukemia in which large natural killer (NK) cells (a type of white blood cell) that contain granules (small particles) are found in the blood. It is a chronic disease that may last for a long time and get worse. Also called NK-LGL leukemia and NK-LGLL."
+    },
+    "otherLanguages": [
+        {
+            "language": "es",
+            "termName": "leucemia linfocítica granular de células citolíticas naturales grandes",
+            "prettyUrlName": "leucemia-linfocitica-granular-de-celulas-citoliticas-naturales-grandes"
+        }
+    ],
+    "relatedResources": [],
+    "media": []
+}

--- a/support/mock-data/Terms/Cancer.gov/Patient/es/644322__leucemia-linfocitica-granular-de-celulas-citoliticas-naturales-grandes.json
+++ b/support/mock-data/Terms/Cancer.gov/Patient/es/644322__leucemia-linfocitica-granular-de-celulas-citoliticas-naturales-grandes.json
@@ -1,0 +1,26 @@
+{
+    "termId": 644322,
+    "language": "es",
+    "dictionary": "Cancer.gov",
+    "audience": "Patient",
+    "termName": "leucemia linfocítica granular de células citolíticas naturales grandes",
+    "firstLetter": "l",
+    "prettyUrlName": null,
+    "pronunciation": {
+        "key": null,
+        "audio": "https://nci-media-dev.cancer.gov/pdq/media/audio/726073.mp3"
+    },
+    "definition": {
+        "html": "Tipo de leucemia por la que se encuentran en la sangre células citolíticas naturales (CN) grandes que contienen gránulos (un tipo de glóbulo blanco). Es una enfermedad crónica que puede durar por largo tiempo y empeorar. También se llama leucemia LGG-CN y LLGG-CN.",
+        "text": "Tipo de leucemia por la que se encuentran en la sangre células citolíticas naturales (CN) grandes que contienen gránulos (un tipo de glóbulo blanco). Es una enfermedad crónica que puede durar por largo tiempo y empeorar. También se llama leucemia LGG-CN y LLGG-CN."
+    },
+    "otherLanguages": [
+        { 
+            "language": "en",
+            "termName": "natural killer-cell large granular lymphocyte leukemia",
+            "prettyUrlName": "natural-killer-cell-large-granular-lymphocyte-leukemia"
+        }
+    ],
+    "relatedResources": [],
+    "media": []
+}

--- a/support/mock-data/Terms/expand/Cancer.gov/Patient/en/A.json
+++ b/support/mock-data/Terms/expand/Cancer.gov/Patient/en/A.json
@@ -31,7 +31,7 @@
       "audience":"Patient",
       "termName":"A6",
       "firstLetter":"a",
-      "prettyUrlName":"a6",
+      "prettyUrlName": null,
       "pronunciation":null,
       "definition":{
         "html":"A substance being studied in the treatment of cancer. A6 is a small piece of a protein called urokinase (an enzyme that dissolves blood clots or prevents them from forming). It is a type of antiangiogenesis agent and a type of antimetastatic agent. Also called urokinase plasminogen activator (uPA)-derived peptide A6.",
@@ -71,7 +71,7 @@
       "audience":"Patient",
       "termName":"AAT deficiency",
       "firstLetter":"a",
-      "prettyUrlName":"aat-deficiency",
+      "prettyUrlName":null,
       "pronunciation":{
         "key":"(… deh-FIH-shun-see)",
         "audio":"https://nci-media-dev.cancer.gov/pdq/media/audio/798897.mp3"

--- a/support/mock-data/Terms/expand/Cancer.gov/Patient/es/A.json
+++ b/support/mock-data/Terms/expand/Cancer.gov/Patient/es/A.json
@@ -11,7 +11,7 @@
       "audience":"Patient",
       "termName":"A33",
       "firstLetter":"a",
-      "prettyUrlName":"a33",
+      "prettyUrlName":null,
       "pronunciation":null,
       "definition":{
         "html":"Tipo de anticuerpo monoclonal que se usa para la detección o el tratamiento de cáncer. Los anticuerpos monoclonales son sustancias producidas en el laboratorio que pueden localizar las células cancerosas y unirse a ellas.",
@@ -51,7 +51,7 @@
       "audience":"Patient",
       "termName":"AAF-EE",
       "firstLetter":"a",
-      "prettyUrlName":"aaf-ee",
+      "prettyUrlName":null,
       "pronunciation":null,
       "definition":{
         "html":"Procedimiento mediante el que se toma una muestra de tejido para examinarla bajo un microscopio. Se inserta por la boca hasta el esófago un endoscopio con una sonda de ecografía y una aguja de biopsia. Un endoscopio es un instrumento delgado con forma de tubo que tiene una luz y una lente para observar. La sonda de ecografía se usa para hacer rebotar ondas de sonido de alta energía contra los órganos y tejidos internos para obtener una imagen en un monitor. La imagen ayuda al médico a ver el lugar donde está la aguja de biopsia. También se llama aspiración con aguja fina guiada por ecografía endoscópica.",

--- a/support/mock-data/Terms/search/Cancer.gov/Patient/en/Begins/meta.json
+++ b/support/mock-data/Terms/search/Cancer.gov/Patient/en/Begins/meta.json
@@ -30,7 +30,7 @@
       "audience": "Patient",
       "termName": "metabolic",
       "firstLetter": "m",
-      "prettyUrlName": "metabolic",
+      "prettyUrlName": null,
       "pronunciation": {
         "key": "(MEH-tuh-BAH-lik)",
         "audio": "https://nci-media-dev.cancer.gov/pdq/media/audio/704100.mp3"
@@ -68,7 +68,7 @@
       "audience": "Patient",
       "termName": "metabolic disorder",
       "firstLetter": "m",
-      "prettyUrlName": "metabolic-disorder",
+      "prettyUrlName": null,
       "pronunciation": {
         "key": "(MEH-tuh-BAH-lik dis-OR-der)",
         "audio": "https://nci-media-dev.cancer.gov/pdq/media/audio/704097.mp3"

--- a/support/mock-data/Terms/search/Cancer.gov/Patient/en/Contains/meta.json
+++ b/support/mock-data/Terms/search/Cancer.gov/Patient/en/Contains/meta.json
@@ -30,7 +30,7 @@
       "audience": "Patient",
       "termName": "agnogenic myeloid metaplasia",
       "firstLetter": "a",
-      "prettyUrlName": "agnogenic-myeloid-metaplasia",
+      "prettyUrlName": null,
       "pronunciation": {
         "key": "(ag-noh-JEH-nik MY-eh-loyd meh-tuh-PLAY-zhuh)",
         "audio": "https://nci-media-dev.cancer.gov/pdq/media/audio/710152.mp3"
@@ -68,7 +68,7 @@
       "audience": "Patient",
       "termName": "bone marrow metastasis",
       "firstLetter": "b",
-      "prettyUrlName": "bone-marrow-metastasis",
+      "prettyUrlName": null,
       "pronunciation": {
         "key": "(bone MAYR-oh meh-TAS-tuh-sis)",
         "audio": "https://nci-media-dev.cancer.gov/pdq/media/audio/705694.mp3"

--- a/support/mock-data/Terms/search/Cancer.gov/Patient/es/Begins/metá.json
+++ b/support/mock-data/Terms/search/Cancer.gov/Patient/es/Begins/metá.json
@@ -30,7 +30,7 @@
       "audience": "Patient",
       "termName": "metabolismo",
       "firstLetter": "m",
-      "prettyUrlName": "metabolismo",
+      "prettyUrlName": null,
       "pronunciation": {
         "key": null,
         "audio": "https://nci-media-dev.cancer.gov/pdq/media/audio/707784.mp3"
@@ -68,7 +68,7 @@
       "audience": "Patient",
       "termName": "metabolismo celular",
       "firstLetter": "m",
-      "prettyUrlName": "metabolismo-celular",
+      "prettyUrlName": null,
       "pronunciation": {
         "key": null,
         "audio": "https://nci-media-dev.cancer.gov/pdq/media/audio/704201.mp3"

--- a/support/mock-data/Terms/search/Cancer.gov/Patient/es/Contains/metá.json
+++ b/support/mock-data/Terms/search/Cancer.gov/Patient/es/Contains/metá.json
@@ -11,7 +11,7 @@
       "audience": "Patient",
       "termName": "acidosis metabólica",
       "firstLetter": "a",
-      "prettyUrlName": "acidosis-metabolica",
+      "prettyUrlName": null,
       "pronunciation": {
         "key": null,
         "audio": "https://nci-media-dev.cancer.gov/pdq/media/audio/704491.mp3"
@@ -49,7 +49,7 @@
       "audience": "Patient",
       "termName": "azoximetano",
       "firstLetter": "a",
-      "prettyUrlName": "azoximetano",
+      "prettyUrlName": null,
       "pronunciation": {
         "key": null,
         "audio": "https://nci-media-dev.cancer.gov/pdq/media/audio/711187.mp3"


### PR DESCRIPTION
* Update term links to use pretty URL name if set, term ID if not
* Update term unit test to reflect changes to link URLs
* Add terms without pretty URLs for unit and integration tests
* Add integration tests for pretty URL name vs term ID URLS
* Closes #121