### PR TITLE
(#107) Spanish no matching expand error text

### DIFF
--- a/cypress/integration/ViewTermsByLetter.feature
+++ b/cypress/integration/ViewTermsByLetter.feature
@@ -3,7 +3,7 @@ Feature: View Terms by letter
 
   Scenario: User appends /expand to the URL and tries to access the dictionary
     Given user appends "/expand" to the URL
-    When user tries to go to this URL, system should return the "No Matches Found" page for language "en"
+    When user tries to go to this URL, system should return the Expand "No Matches Found" page for language "en"
 
   Scenario: User selects a letter from A-Z list on dictionaries
     Given user is on the dictionary landing page or results page

--- a/cypress/integration/ViewTermsByLetterGeneticsSpanish.feature
+++ b/cypress/integration/ViewTermsByLetterGeneticsSpanish.feature
@@ -3,10 +3,10 @@ Feature: View Terms by letter for Genetics
   Background:
     Given "audience" is set to "HealthProfessional"
     Given "dictionaryName" is set to "Genetics"
-    Given "language" is set to "en"
+    Given "language" is set to "es"
 
   Scenario: User clicks on a letter in the A-Z list for results and gets no matches found for the selected letter
     Given user is on landing Genetics Terms page
     When user selects letter "Y" from A-Z list
-    Then the system returns user to the search results page for the search term "Y" URL has "/expand"
-    When user tries to go to this URL, system should return the Expand "No Matches Found" page for language "en"
+    Then the system returns user to the search results page for the search term "Y" URL has "/ampliar"
+    When user tries to go to this URL, system should return the Expand "No Matches Found" page for language "es"

--- a/cypress/integration/ViewTermsByLetterSpanish.feature
+++ b/cypress/integration/ViewTermsByLetterSpanish.feature
@@ -6,7 +6,7 @@ Feature: View Terms by letter Spanish
 
   Scenario: User appends /expand to the URL and tries to access the dictionary
     Given user appends "/ampliar" to the URL
-    When user tries to go to this URL, system should return the "No Matches Found" page for language "es"
+    When user tries to go to this URL, system should return the Expand "No Matches Found" page for language "es"
 
   Scenario: User selects a letter from A-Z list on dictionaries
     Given user is on the dictionary landing page or results page

--- a/cypress/integration/common/index.js
+++ b/cypress/integration/common/index.js
@@ -1,11 +1,11 @@
 import { And, Given, Then, When } from "cypress-cucumber-preprocessor/steps";
 import {
-  NO_MATCHING_TEXT_EXPAND,
-  NO_MATCHING_TEXT_EXPAND_SPANISH,
   queryType,
   searchMatchType,
   testIds
 } from "../../../src/constants";
+
+import { i18n } from "../../../src/utils";
 
 const baseURL = Cypress.config('baseUrl');
 
@@ -311,12 +311,17 @@ Then('there is an resource item with the following link and text',dataTable =>{
     ------------------------------
 */
 
-When('user tries to go to this URL, system should return the {string} page for language {string}', (text, lang) => {
-  cy.get(`p[data-testid='${testIds.NO_MATCHING_RESULTS}']`)
-      .should(
+When('user tries to go to this URL, system should return the Expand {string} page for language {string}', (text, lang) => {
+  cy.window().then((win) => {
+    if ( win.INT_TEST_APP_PARAMS ) {
+      const { language } = win.INT_TEST_APP_PARAMS;
+      cy.get(`p[data-testid='${testIds.NO_MATCHING_RESULTS}']`)
+        .should(
           'have.text',
-          lang === 'es' ? NO_MATCHING_TEXT_EXPAND_SPANISH : NO_MATCHING_TEXT_EXPAND
-      );
+          i18n.noMatchingExpand[language]  
+        );   
+    }
+  })
 });
 
 Then('the system returns user to the search results page for the search term {string} URL has {string}', (term, destURL) => {

--- a/src/constants.js
+++ b/src/constants.js
@@ -6,10 +6,6 @@ export const AZListArray = "abcdefghijklmnopqrstuvwxyz#".split('');
 // paging are not going to be implemented for now ( 10,000 )
 export const DEFAULT_RESULT_SIZE = 10000;
 
-// No Matching text
-export const NO_MATCHING_TEXT_EXPAND = "No matches were found for your selected letter. Please try a new search, or click a different letter in the alphabet and browse through the list of terms that begin with that letter.";
-export const NO_MATCHING_TEXT_EXPAND_SPANISH = "No matches were found for your selected letter. Please try a new search, or click a different letter in the alphabet and browse through the list of terms that begin with that letter.";
-
 export const searchMatchType = {
   beginsWith: "Begins",
   contains: "Contains"

--- a/src/utils/i18n.js
+++ b/src/utils/i18n.js
@@ -20,12 +20,16 @@ export const i18n = {
         es: "Se produjo un error. Por favor, vuelva a intentar más tarde."
     },
     moreInformation: {
-      en: "More Information",
-      es: "Más información"
+        en: "More Information",
+        es: "Más información"
     },
     noMatchingTextSearch: {
-      en: "No matches were found for the word or phrase you entered. Please check your spelling, and try searching again. You can also type the first few letters of your word or phrase, or click a letter in the alphabet and browse through the list of terms that begin with that letter.",
-      es: "No se encontraron resultados para lo que usted busca. Revise si escribió correctamente e inténtelo de nuevo. También puede escribir las primeras letras de la palabra o frase que busca o hacer clic en la letra del alfabeto y revisar la lista de términos que empiezan con esa letra."
+        en: "No matches were found for the word or phrase you entered. Please check your spelling, and try searching again. You can also type the first few letters of your word or phrase, or click a letter in the alphabet and browse through the list of terms that begin with that letter.",
+        es: "No se encontraron resultados para lo que usted busca. Revise si escribió correctamente e inténtelo de nuevo. También puede escribir las primeras letras de la palabra o frase que busca o hacer clic en la letra del alfabeto y revisar la lista de términos que empiezan con esa letra."
+    },
+    noMatchingExpand: {
+        en: "No matches were found for your selected letter. Please try a new search, or click a different letter in the alphabet and browse through the list of terms that begin with that letter.",
+        es: "No hay resultados para su búsqueda. Inicie una nueva búsqueda o haga clic en otra letra del alfabeto para consultar términos que empiecen con esa letra."
     },
     search: {
         en: "Search",

--- a/src/views/Home/__tests__/Home.en.test.js
+++ b/src/views/Home/__tests__/Home.en.test.js
@@ -4,7 +4,7 @@ import { ClientContextProvider } from "react-fetching-library";
 import { MemoryRouter } from "react-router";
 import { MockAnalyticsProvider } from "../../../tracking";
 
-import { NO_MATCHING_TEXT_EXPAND, searchMatchType, testIds } from "../../../constants";
+import { searchMatchType, testIds } from "../../../constants";
 import Home from "../Home";
 import { useStateValue } from "../../../store/store.js";
 import { i18n, fixtures } from "../../../utils";
@@ -128,7 +128,7 @@ describe("Home component(English)", () => {
     test("NoMatchingResults component is rendered for expand path with no params", () => {
       const { getByTestId } = wrapper;
       expect(getByTestId(testIds.NO_MATCHING_RESULTS).textContent).toBe(
-        NO_MATCHING_TEXT_EXPAND
+        i18n.noMatchingExpand[language]
       );
     });
   });

--- a/src/views/Home/__tests__/Home.es.test.js
+++ b/src/views/Home/__tests__/Home.es.test.js
@@ -4,10 +4,10 @@ import { ClientContextProvider } from "react-fetching-library";
 import { MemoryRouter } from "react-router";
 import { MockAnalyticsProvider } from "../../../tracking";
 
-import { NO_MATCHING_TEXT_EXPAND, testIds } from "../../../constants";
+import { testIds } from "../../../constants";
 import Home from "../Home";
 import { useStateValue } from "../../../store/store.js";
-import { fixtures } from "../../../utils";
+import { i18n, fixtures } from "../../../utils";
 
 jest.mock("../../../store/store.js");
 
@@ -78,5 +78,55 @@ describe("Home component(Spanish)", () => {
       "href",
       "/cancer-terms"
     );
+  });
+
+  describe("Load Spanish Home component using expand path with no params", () => {
+    beforeEach(async () => {
+      cleanup();
+      await act(async () => {
+        wrapper = render(
+          <MockAnalyticsProvider>
+            <MemoryRouter initialEntries={["/ampliar"]}>
+              <ClientContextProvider client={client}>
+                <Home />
+              </ClientContextProvider>
+            </MemoryRouter>
+          </MockAnalyticsProvider>
+        );
+      });
+    });
+    afterEach(cleanup);
+
+    test("NoMatchingResults component is rendered for ampliar path with no params", () => {
+      const { getByTestId } = wrapper;
+      expect(getByTestId(testIds.NO_MATCHING_RESULTS).textContent).toBe(
+        i18n.noMatchingExpand[language]
+      );
+    });
+  });
+
+  describe("Load Spanish Home component using search path with no params", () => {
+    beforeEach(async () => {
+      cleanup();
+      await act(async () => {
+        wrapper = render(
+          <MockAnalyticsProvider>
+            <MemoryRouter initialEntries={["/buscar"]}>
+              <ClientContextProvider client={client}>
+                <Home />
+              </ClientContextProvider>
+            </MemoryRouter>
+          </MockAnalyticsProvider>
+        );
+      });
+    });
+    afterEach(cleanup);
+
+    test("NoMatchingResults component is rendered with no matching search text for buscar path with no params", () => {
+      const { getByTestId } = wrapper;
+      expect(getByTestId(testIds.NO_MATCHING_RESULTS).textContent).toBe(
+          i18n.noMatchingTextSearch[language]
+      );
+    });
   });
 });

--- a/src/views/Terms/NoMatchingResults.jsx
+++ b/src/views/Terms/NoMatchingResults.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { useLocation } from "react-router-dom";
 
-import { NO_MATCHING_TEXT_EXPAND, queryType, testIds } from "../../constants";
+import { queryType, testIds } from "../../constants";
 import { useStateValue } from "../../store/store";
 import { i18n } from "../../utils";
 
@@ -15,7 +15,7 @@ const NoMatchingResults = () => {
     return (
         <p data-testid={testIds.NO_MATCHING_RESULTS}>
             { isExpand
-                ? NO_MATCHING_TEXT_EXPAND
+                ? i18n.noMatchingExpand[language]
                 : i18n.noMatchingTextSearch[language]
             }
         </p>

--- a/src/views/Terms/__tests__/NoMatchingResults.test.js
+++ b/src/views/Terms/__tests__/NoMatchingResults.test.js
@@ -2,7 +2,7 @@ import { render } from "@testing-library/react";
 import React from 'react';
 import { MemoryRouter } from "react-router";
 
-import { NO_MATCHING_TEXT_EXPAND, testIds } from "../../../constants";
+import { testIds } from "../../../constants";
 import { NoMatchingResults } from "../index";
 import { useStateValue } from "../../../store/store";
 import { i18n } from "../../../utils";


### PR DESCRIPTION
* Move no matching expand error text strings
* Update NoMatchingResults to display correct text
* Update NoMatchingResults unit tests for en/es
* Update Home unit tests to include error text tests in en/es
* Update integration tests for Expand in en/es for Terms and Genetics