### PR TITLE
(#114,#116) Whitespace style updates for Term and phonetic/H1 and content

### DIFF
--- a/src/views/Definition/Definition.jsx
+++ b/src/views/Definition/Definition.jsx
@@ -264,6 +264,7 @@ const Definition = ({tracking}) => {
           {renderPronunciation()}
           {payload.definition && (
             <div
+              className="term-description"
               data-testid={testIds.TERM_DEF_DESCRIPTION}
               dangerouslySetInnerHTML={{ __html: payload.definition.html }}
             ></div>

--- a/src/views/Definition/Definition.scss
+++ b/src/views/Definition/Definition.scss
@@ -12,3 +12,7 @@
     margin-top: 40px;
   }
 }
+
+.term-title + .term-description {
+  margin-top: 10px;
+}

--- a/src/views/Terms/TermList.scss
+++ b/src/views/Terms/TermList.scss
@@ -8,6 +8,12 @@
   dt {
     margin-bottom: 0;
     display: inline-block;
+
+    + .pronunciation {
+      .pronunciation__key {
+        margin-left: 8px;
+      }
+    }
   }
 
   dd.pronunciation {
@@ -29,6 +35,7 @@
     padding-top: 0;
     padding-bottom: 0;
     height: 22px;
+    width: 34px;
   }
 
   .pronunciation__key {


### PR DESCRIPTION
Closes #114
Closes #116

* Added space missing between Term and phonetic spelling for Terms
* Added extra bottom padding between H1 and content when there is no audio icon or pronunciation for Definition