### PR TITLE
(#26) Single search result redirects to definition

### DIFF
--- a/cypress/integration/EnglishKeywordSearch.feature
+++ b/cypress/integration/EnglishKeywordSearch.feature
@@ -62,3 +62,11 @@ Feature: As a user, I would like to be able to enter keywords and have the optio
         Then the page contains meta tags with the following names
             | name  | content |
             | robots | noindex |
+
+    Scenario: As a user, if my search term only returns one result, I would like to be redirected to the term’s page instead of the results page. 
+        Given the user is viewing the dictionary landing page
+        When user types "metastatic" in the search bar
+        And user clicks on "Search" button 
+        Then the user is redirected to "/def/metastatic"
+        And the search bar on the page does not maintain the user’s term
+        And "Starts with" option is selected

--- a/cypress/integration/common/search.js
+++ b/cypress/integration/common/search.js
@@ -63,3 +63,11 @@ Then('the page contains meta tags with the following names', dataTable => {
     cy.get(locator).should('have.attr', 'content').and('be.eq', content);
   }
 });
+
+Then('the user is redirected to {string}', (redirectUrl) => {
+  cy.location('pathname').should('include', redirectUrl);
+});
+
+Then('the search bar on the page does not maintain the user’s term', () => {
+  cy.get('#keywords').invoke('val').should('be.empty');
+});

--- a/src/views/Terms/TermList.jsx
+++ b/src/views/Terms/TermList.jsx
@@ -1,8 +1,9 @@
 import React, { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 import Spinner from "../../components/atomic/spinner";
 import { queryType } from "../../constants";
-import { useCustomQuery } from "../../hooks";
+import { useAppPaths, useCustomQuery } from "../../hooks";
 import NoMatchingResults from "./NoMatchingResults";
 import { getExpandCharResults, getSearchResults } from "../../services/api/actions";
 import { useStateValue } from "../../store/store";
@@ -15,6 +16,19 @@ const TermList = ({ matchType, query, type }) => {
         : getExpandCharResults(query);
     const { loading, payload } = useCustomQuery( queryAction );
     const [{ language }] = useStateValue();
+    const { DefinitionPath } = useAppPaths();
+    const navigate = useNavigate();
+
+    useEffect( () => {
+        if ( payload && payload.results && payload.results.length === 1 ) {
+            const idOrName = payload.results[0].prettyUrlName
+                ? payload.results[0].prettyUrlName
+                : payload.results[0].termId;
+
+            navigate(DefinitionPath({idOrName}));
+        }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [ payload]);
 
     useEffect( () => {
         window.scrollTo(0,0);
@@ -25,7 +39,7 @@ const TermList = ({ matchType, query, type }) => {
             { loading && <Spinner /> }
             { !loading && payload &&
                 <div className="dictionary-list-container results" data-dict-type="term">
-                    { payload.results && payload.results.length > 0
+                    { payload.results && payload.results.length > 1
                         ?
                             <>
                                 <h4>{ payload.meta.totalResults } { i18n.termListTitle[language] }: { decodeURIComponent(query) } </h4>

--- a/src/views/Terms/__tests__/TermList.test.js
+++ b/src/views/Terms/__tests__/TermList.test.js
@@ -1,7 +1,7 @@
 import { act, cleanup, render } from "@testing-library/react";
 import React from 'react';
 import { ClientContextProvider } from "react-fetching-library";
-import { MemoryRouter } from "react-router";
+import { MemoryRouter, useLocation, useNavigate } from "react-router-dom";
 
 import { testIds } from "../../../constants";
 import { TermList } from "../index";
@@ -11,6 +11,7 @@ import fixtures from "../../../utils/fixtures";
 jest.mock("../../../store/store");
 
 let client;
+let location;
 let termList;
 let wrapper;
 
@@ -18,6 +19,11 @@ const query = "A";
 const queryFile = `${query}.json`;
 const { getFixture } = fixtures;
 const fixturePath = `/Terms/expand/Cancer.gov/Patient`;
+
+function ComponentWithLocation({ RenderComponent, query }) {
+    location = useLocation();
+    return <RenderComponent query={query} />;
+}
 
 describe('TermList component rendered with English', () => {
     const language = "en";
@@ -63,7 +69,6 @@ describe('TermList component rendered with English', () => {
     afterEach(() => {
         cleanup();
     });
-
     test(`"${termListCount} results found for: ${query}" should be present `, () => {
         const { getByText } = wrapper;
         expect(getByText(`${termListCount} results found for: ${query}`)).toBeInTheDocument();
@@ -90,6 +95,18 @@ describe('TermList component rendered with English', () => {
                     }
                 })
             };
+            const dictionaryName = "Cancer.gov";
+            const dictionaryTitle = "NCI Dictionary of Cancer Terms";
+            useStateValue.mockReturnValue([
+                {
+                    appId: "mockAppId",
+                    basePath: "/",
+                    dictionaryName,
+                    dictionaryTitle,
+                    language,
+                    searchBoxTitle
+                }
+            ]);
 
             await act(async () => {
                 wrapper = render(
@@ -119,5 +136,130 @@ describe('TermList component rendered with English', () => {
             expect(window.scrollTo).toHaveBeenCalledTimes(1);
             expect(window.scrollTo).toHaveBeenLastCalledWith(0, 0);
         });
+    });
+
+    describe(`Tests using lung cancer as query parameter for term`, () => {
+        beforeEach(cleanup);
+        afterEach(cleanup);
+        const query = "lung cancer";
+
+        test(`Redirected to definition page with pretty URL name for query "${query}" with one term result`, async () => {
+
+            const client = {
+                query: async () => ({
+                    error: false,
+                    status: 200,
+                    payload: {
+                        meta: {
+                            totalResults: 1,
+                            from: 0
+                        },
+                        results: [
+                            {
+                                termId: 445043,
+                                language: "en",
+                                dictionary: "Cancer.gov",
+                                audience: "Patient",
+                                termName: "lung cancer",
+                                firstLetter: "l",
+                                prettyUrlName: "lung-cancer",
+                                pronunciation: {
+                                    key: "(lung KAN-ser)",
+                                    audio: "https://nci-media.cancer.gov/pdq/media/audio/714622.mp3"
+                                },
+                                definition: {
+                                    html: "Cancer that forms in tissues of the lung, usually in the cells lining air passages. The two main types are small cell lung cancer and non-small cell lung cancer. These types are diagnosed based on how the cells look under a microscope.",
+                                    text: "Cancer that forms in tissues of the lung, usually in the cells lining air passages. The two main types are small cell lung cancer and non-small cell lung cancer. These types are diagnosed based on how the cells look under a microscope."
+                                },
+                                otherLanguages: [],
+                                relatedResources: [],
+                                media: []
+                            }
+                        ],
+                        links: null
+                    },
+                    loading: false
+                })
+            };
+
+            const expectedLocationObject = {
+                pathname: '/def/lung-cancer',
+                search: '',
+                hash: '',
+                state: null,
+                key: expect.any(String)
+            };
+
+            await act( async () => {
+                wrapper = await render(
+                    <MemoryRouter initialEntries={['/']}>
+                        <ClientContextProvider client={client}>
+                            <ComponentWithLocation RenderComponent={TermList} />
+                        </ClientContextProvider>
+                    </MemoryRouter>
+                );
+            });
+            expect(location).toMatchObject(expectedLocationObject);
+        });
+
+        test(`Redirected to definition page with term ID for query "${query}" with one term result`, async () => {
+
+            const client = {
+                query: async () => ({
+                    error: false,
+                    status: 200,
+                    payload: {
+                        meta: {
+                            totalResults: 1,
+                            from: 0
+                        },
+                        results: [
+                            {
+                                termId: 445043,
+                                language: "en",
+                                dictionary: "Cancer.gov",
+                                audience: "Patient",
+                                termName: "lung cancer",
+                                firstLetter: "l",
+                                prettyUrlName: null,
+                                pronunciation: {
+                                    key: "(lung KAN-ser)",
+                                    audio: "https://nci-media.cancer.gov/pdq/media/audio/714622.mp3"
+                                },
+                                definition: {
+                                    html: "Cancer that forms in tissues of the lung, usually in the cells lining air passages. The two main types are small cell lung cancer and non-small cell lung cancer. These types are diagnosed based on how the cells look under a microscope.",
+                                    text: "Cancer that forms in tissues of the lung, usually in the cells lining air passages. The two main types are small cell lung cancer and non-small cell lung cancer. These types are diagnosed based on how the cells look under a microscope."
+                                },
+                                otherLanguages: [],
+                                relatedResources: [],
+                                media: []
+                            }
+                        ],
+                        links: null
+                    },
+                    loading: false
+                })
+            };
+
+            const expectedLocationObject = {
+                pathname: '/def/445043',
+                search: '',
+                hash: '',
+                state: null,
+                key: expect.any(String)
+            };
+
+            await act( async () => {
+                wrapper = await render(
+                    <MemoryRouter initialEntries={['/']}>
+                        <ClientContextProvider client={client}>
+                            <ComponentWithLocation RenderComponent={TermList} />
+                        </ClientContextProvider>
+                    </MemoryRouter>
+                );
+            });
+            expect(location).toMatchObject(expectedLocationObject);
+        });
+
     });
 });

--- a/support/mock-data/Terms/search/Cancer.gov/Patient/en/Begins/metastatic.json
+++ b/support/mock-data/Terms/search/Cancer.gov/Patient/en/Begins/metastatic.json
@@ -1,0 +1,71 @@
+{
+  "meta": {
+    "totalResults": 1,
+    "from": 0
+  },
+  "results": [
+    {
+      "termId": 44058,
+      "language": "en",
+      "dictionary": "Cancer.gov",
+      "audience": "Patient",
+      "termName": "metastatic",
+      "firstLetter": "m",
+      "prettyUrlName": "metastatic",
+      "pronunciation": {
+        "key": "(meh-tuh-STA-tik)",
+        "audio": "https://nci-media-dev.cancer.gov/pdq/media/audio/704104.mp3"
+      },
+      "definition": {
+        "html": "Having to do\n          with metastasis, which is the spread of cancer from the\n          primary site (place where it started) to other places in\n          the body.",
+        "text": "Having to do\n          with metastasis, which is the spread of cancer from the\n          primary site (place where it started) to other places in\n          the body."
+      },
+      "otherLanguages": [ 
+        {
+          "language": "es",
+          "termName": "metastásico",
+          "prettyUrlName": "metastasico"
+        }
+      ],
+      "relatedResources": [
+        {
+          "Url": "https://www.cancer.gov/types/metastatic-cancer",
+          "Type": "External",
+          "Text": "Metastatic Cancer"
+        }
+      ],
+      "media": [
+        {
+          "Type": "Image",
+          "ImageSources": [
+            {
+              "Size": "original",
+              "Src": "https://nci-media-dev.cancer.gov/pdq/media/images/764135.jpg"
+            },
+            {
+              "Size": "571",
+              "Src": "https://nci-media-dev.cancer.gov/pdq/media/images/764135-571.jpg"
+            },
+            {
+              "Size": "750",
+              "Src": "https://nci-media-dev.cancer.gov/pdq/media/images/764135-750.jpg"
+            }
+          ],
+          "Ref": "CDR0000764135",
+          "Alt": "Metastasis; drawing shows primary cancer that has spread from the colon to other parts of the body (the liver and the lung). An inset shows cancer cells spreading from the primary cancer, through the blood and lymph system, to another part of the body where a metastatic tumor has formed.",
+          "Caption": "Metastasis. In metastasis, cancer cells break away from where they first formed (primary cancer), travel through the blood or lymph system, and form new tumors (metastatic tumors) in other parts of the body. The metastatic tumor is the same type of cancer as the primary tumor. "
+        },
+        {
+          "Type": "Video",
+          "Hosting": "youtube",
+          "Ref": "CDR0000787719",
+          "UniqueId": "fQwar_-QdiQ",
+          "Template": "Video75NoTitle",
+          "Title": "Metastasis: How Cancer Spreads",
+          "Caption": "Many cancer deaths are caused when cancer moves from the original tumor and spreads to other tissues and organs. This is called metastatic cancer. This animation shows how cancer cells travel from the place in the body where they first formed to other parts of the body."
+        }
+      ]
+      
+    }
+  ]
+}


### PR DESCRIPTION
* Update TermList to redirect to Definition if search returns one term
* Add unit tests
* Add integration tests and mock data
* Closes #26