### PR TITLE
(#148) 404 - Page Not Found

### DIFF
--- a/cypress/integration/ApiFailurePage.feature
+++ b/cypress/integration/ApiFailurePage.feature
@@ -1,10 +1,5 @@
 Feature: As a user, I need to encounter an error page when a call to the API fails.
 
-    Background:
-        Given "audience" is set to ""
-        And "language" is set to "en"
-        And "dictionaryName" is set to ""
-
     Scenario: User encounters an error page when API fails
-        Given the user is viewing the definition with the pretty url "metastatic"
+        Given the user is viewing the definition with the pretty url "foobar"
         Then the user gets an error page that reads "An error occurred. Please try again later."

--- a/cypress/integration/ApiFailureSpanishPage.feature
+++ b/cypress/integration/ApiFailureSpanishPage.feature
@@ -1,10 +1,8 @@
 Feature: As a user, I need to encounter a Spanish error page when a call to the API fails.
 
     Background:
-        Given "audience" is set to ""
         And "language" is set to "es"
-        And "dictionaryName" is set to ""
 
     Scenario: User encounters an error page when API fails
-        Given the user is viewing the definition with the pretty url "metastásico"
+        Given the user is viewing the definition with the pretty url "foobar"
         Then the user gets an error page that reads "Se produjo un error. Por favor, vuelva a intentar más tarde."

--- a/cypress/integration/AppAnalytics/PageNotFoundPageLoad.feature
+++ b/cypress/integration/AppAnalytics/PageNotFoundPageLoad.feature
@@ -1,0 +1,62 @@
+Feature: Page Not Found Analytics
+
+	Scenario: Page Load Analytics fires for a 404 on the terms page
+		Given "audience" is set to "Patient"
+		And "dictionaryTitle" is set to "NCI Dictionary of Cancer Terms"
+		And "dictionaryName" is set to "Cancer.gov"
+		And "language" is set to "en"
+		And "baseHost" is set to "http://localhost:3000"
+		And "canonicalHost" is set to "https://www.cancer.gov"
+		And "siteName" is set to "National Cancer Institute"
+		And "analyticsChannel" is set to "Publications"
+		And "analyticsPublishedDate" is set to "02/02/2011"
+		When the user is viewing the definition with the pretty url "chicken"
+		And page title on error page is "Page Not Found"
+		And browser waits
+		Then there should be an analytics event with the following details
+			| key																			| value                          	|
+			| type																		| PageLoad												|
+			| event																		| GlossaryApp:Load:PageNotFound		|
+			| page.audience      											| Patient 												|
+			| page.channel   													| Publications 										|
+			| page.language      											| english 												|
+			| page.metaTitle													| Page Not Found 									|
+			| page.name          											| www.cancer.gov/def/chicken      |
+			| page.title         											| Page Not Found 									|
+			| page.type																| nciAppModulePage   							|
+			| page.contentGroup  											| NCI Dictionary of Cancer Terms 	|
+			| page.publishedDate 											| 02/02/2011 											|
+			| page.additionalDetails.analyticsName   	| CancerTerms                    	|
+			| page.additionalDetails.dictionaryTitle	| NCI Dictionary of Cancer Terms 	|
+			| page.additionalDetails.idOrName					| chicken 												|
+
+
+	Scenario: Page Load Analytics fires for a 404 on the spanish terms page
+		Given "audience" is set to "Patient"
+		And "dictionaryTitle" is set to "Diccionario de cáncer"
+		And "dictionaryName" is set to "Cancer.gov"
+		And "language" is set to "es"
+		And "baseHost" is set to "http://localhost:3000"
+		And "canonicalHost" is set to "https://www.cancer.gov"
+		And "siteName" is set to "Instituto Nacional del Cáncer"
+		And "analyticsChannel" is set to "Publications - Spanish"
+		And "analyticsPublishedDate" is set to "02/02/2011"
+		When the user is viewing the definition with the pretty url "pollo"
+		And page title on error page is "No se encontró la página"
+		And browser waits
+		Then there should be an analytics event with the following details
+			| key																			| value                          	|
+			| type																		| PageLoad												|
+			| event																		| GlossaryApp:Load:PageNotFound		|
+			| page.audience      											| Patient 												|
+			| page.channel   													| Publications - Spanish 					|
+			| page.language      											| spanish 												|
+			| page.metaTitle													| No se encontró la página 				|
+			| page.name          											| www.cancer.gov/def/pollo	      |
+			| page.title         											| No se encontró la página 				|
+			| page.type																| nciAppModulePage   							|
+			| page.contentGroup  											| Diccionario de cáncer 					|
+			| page.publishedDate 											| 02/02/2011 											|
+			| page.additionalDetails.analyticsName   	| CancerTerms                    	|
+			| page.additionalDetails.dictionaryTitle	| Diccionario de cáncer 					|
+			| page.additionalDetails.idOrName					| pollo 													|

--- a/cypress/integration/PageNotFoundEnglish.feature
+++ b/cypress/integration/PageNotFoundEnglish.feature
@@ -1,0 +1,9 @@
+Feature: Page Not Found Error
+
+	Scenario: Page not found should be displayed when a user visits the definition page with a pretty url that doesn't exist
+		Given the user is viewing the definition with the pretty url "chicken"
+		Then page title on error page is "Page Not Found"
+		And the following links and texts exist on the page
+				|	https://www.cancer.gov | homepage	|
+				| https://www.cancer.gov/types | cancer type	|
+				|	https://www.cancer.gov/contact | Get in touch	|

--- a/cypress/integration/PageNotFoundSpanish.feature
+++ b/cypress/integration/PageNotFoundSpanish.feature
@@ -1,0 +1,12 @@
+Feature: Page Not Found Error Spanish
+
+	Background:
+		Given "language" is set to "es"
+
+	Scenario: Page not found should be displayed when a user visits the definition page with a pretty url that doesn't exist
+		Given the user is viewing the definition with the pretty url "pollo"
+		Then page title on error page is "No se encontró la página"
+		And the following links and texts exist on the page
+				|	https://www.cancer.gov/espanol | página principal	|
+				| https://www.cancer.gov/espanol/tipos | tipo de cáncer	|
+				|	https://www.cancer.gov/espanol/contactenos | Contáctenos	|

--- a/cypress/integration/common/index.js
+++ b/cypress/integration/common/index.js
@@ -13,6 +13,15 @@ Then('the page title is {string}', (title) => {
 	cy.get('h1').should('contain', title);
 });
 
+Then('page title on error page is {string}', (title) => {
+	Cypress.on('uncaught:exception', (err, runnable) => {
+		// returning false here to Cypress from
+		// failing the test
+		return false;
+	});
+	cy.get('h1').should('contain', title);
+});
+
 /*
     --------------------
         Page Visits
@@ -733,3 +742,23 @@ Then('browser waits', () => {
 	cy.wait(2000);
 });
 
+
+And(
+	'the following links and texts exist on the page',
+	(dataTable) => {
+		// Split the data table into array of pairs
+		const rawTable = dataTable.rawTable.slice();
+
+		// Verify the total number of links
+		cy.document().then((doc) => {
+			let docLinkArray = doc.querySelectorAll('#main-content a');
+			expect(docLinkArray.length).to.be.eq(rawTable.length);
+		});
+
+		// get the link with the provided url and assert it's text
+		for (let i = 0; i < rawTable.length; i++) {
+			const row = rawTable[i];
+			cy.get(`#main-content a[href='${row[0]}']`).should('have.text', row[1]);
+		}
+	}
+);

--- a/src/App.js
+++ b/src/App.js
@@ -7,6 +7,7 @@ import './styles/dictionaries.scss';
 
 import { useAppPaths } from './hooks';
 import Definition from './views/Definition';
+import PageNotFound from './views/ErrorBoundary/PageNotFound';
 import Home from './views/Home';
 
 const App = ({ tracking }) => {
@@ -37,6 +38,9 @@ const App = ({ tracking }) => {
 				<Route path={SearchPathNoParam()} element={<Home />} />
 				<Route path={SearchPathSpanish()} element={<Home />} />
 				<Route path={SearchPathSpanishNoParam()} element={<Home />} />
+				{window?.location?.host === 'react-app-dev.cancer.gov' &&
+					<Route path="/*" element={<PageNotFound />} />
+				}
 			</Routes>
 		</Router>
 	);

--- a/src/styles/dictionaries.scss
+++ b/src/styles/dictionaries.scss
@@ -11,6 +11,7 @@
 
 //views
 @import '../views/Definition/Definition';
+@import '../views/ErrorBoundary/PageNotFound';
 @import '../views/Terms/TermList';
 
 h1 {

--- a/src/utils/i18n.js
+++ b/src/utils/i18n.js
@@ -35,6 +35,10 @@ export const i18n = {
 		es:
 			'No hay resultados para su búsqueda. Inicie una nueva búsqueda o haga clic en otra letra del alfabeto para consultar términos que empiecen con esa letra.',
 	},
+	pageNotFoundTitle: {
+		en: "Page Not Found",
+		es: "No se encontró la página",
+	},
 	search: {
 		en: 'Search',
 		es: 'Buscar',

--- a/src/views/ErrorBoundary/ErrorBoundary.jsx
+++ b/src/views/ErrorBoundary/ErrorBoundary.jsx
@@ -1,21 +1,34 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+
 import ErrorPage from './ErrorPage';
+import PageNotFound from './PageNotFound';
 
 class ErrorBoundary extends Component {
 	constructor(props) {
 		super(props);
-		this.state = { hasError: false };
+		this.state = {
+			error: null,
+			hasError: false,
+		};
 	}
 
 	static getDerivedStateFromError(error) {
 		// Update state so the next render will show the error page.
-		return { hasError: true };
+		return {
+			error,
+			hasError: true,
+		};
 	}
 
 	render() {
-		if (this.state.hasError) {
-			return <ErrorPage />;
+		const { error, hasError } = this.state;
+		if (hasError) {
+			// Display 404 page only when current route matches a definition route
+			// and a 404 response is returned from the api
+			const showPageNotFound = window.location.pathname.includes('/def') && error.includes('404');
+
+			return showPageNotFound ? <PageNotFound /> : <ErrorPage />;
 		}
 		return this.props.children;
 	}

--- a/src/views/ErrorBoundary/PageNotFound.jsx
+++ b/src/views/ErrorBoundary/PageNotFound.jsx
@@ -1,0 +1,122 @@
+import React, { useEffect, useState } from 'react';
+import { Helmet } from 'react-helmet';
+import { useTracking } from 'react-tracking';
+
+import TextInput from '../../components/atomic/TextInput';
+import { searchMatchType } from '../../constants';
+import { useAppPaths } from '../../hooks';
+import { useStateValue } from '../../store/store';
+import { i18n } from '../../utils';
+
+const PageNotFound = () => {
+	const [{ canonicalHost, language }] = useStateValue();
+	const [searchText, updateSearchText] = useState('');
+	const { SearchPath, SearchPathSpanish } = useAppPaths();
+	const tracking = useTracking();
+
+	useEffect(() => {
+		const pageTitle = i18n.pageNotFoundTitle[language];
+		const requestedPageQuery = window.location.pathname.includes('/def/')
+			? { idOrName: window.location.pathname.split('/def/')[1] }
+			: {};
+		tracking.trackEvent({
+			...requestedPageQuery,
+			event: 'GlossaryApp:Load:PageNotFound',
+			metaTitle: pageTitle,
+			name: `${canonicalHost.replace('https://', '')}${
+				window.location.pathname
+			}`,
+			title: pageTitle,
+			type: 'PageLoad',
+		});
+	}, []);
+
+	const contentPar =
+		language === 'es'
+			? [
+					<>No podemos encontrar la página que busca.</>,
+					<>
+						Visite la{' '}
+						<a href="https://www.cancer.gov/espanol">página principal</a>,
+						busque por{' '}
+						<a href="https://www.cancer.gov/espanol/tipos">tipo de cáncer</a>, o
+						use la casilla de búsqueda en la parte de abajo de esta página.
+					</>,
+					<>
+						¿Tiene una pregunta?{' '}
+						<a href="https://www.cancer.gov/espanol/contactenos">Contáctenos</a>
+						.
+					</>,
+			  ]
+			: [
+					<>We can&apos;t find the page you&apos;re looking for.</>,
+					<>
+						Visit the <a href="https://www.cancer.gov">homepage</a>, browse by{' '}
+						<a href="https://www.cancer.gov/types">cancer type</a>, or use the
+						search below.
+					</>,
+					<>
+						Have a question?{' '}
+						<a href="https://www.cancer.gov/contact">Get in touch</a>.
+					</>,
+			  ];
+
+	const searchPathWithLang = language === 'es' ? SearchPathSpanish : SearchPath;
+
+	const executeSearch = event => {
+		event.preventDefault();
+		const queryString =
+			searchText.length > 1
+				? `${searchText}/?searchMode=${searchMatchType.beginsWith}`
+				: `/`;
+		window.location = `${searchPathWithLang({ searchText: queryString })}`;
+	};
+
+	const renderHelmet = () => {
+		return (
+			<Helmet>
+				<title>{i18n.pageNotFoundTitle[language]}</title>
+				<meta property="dcterms.subject" content="Error Pages" />
+				<meta property="dcterms.type" content="errorpage" />
+			</Helmet>
+		);
+	};
+
+	const updateTextInput = event => {
+		const { value } = event.target;
+		updateSearchText(value);
+	};
+
+	return (
+		<>
+			{renderHelmet()}
+			<div className="error-container">
+				<h1>{i18n.pageNotFoundTitle[language]}</h1>
+				<>
+					{contentPar.map((content, index) => (
+						<p key={index}>{content}</p>
+					))}
+				</>
+				<div className="error-searchbar">
+					<TextInput
+						id="keywords"
+						action={updateTextInput}
+						classes="searchString"
+						label={i18n.search[language]}
+						labelHidden
+					/>
+					<input
+						type="submit"
+						className="submit button postfix"
+						id="btnSearch"
+						title={i18n.search[language]}
+						value={i18n.search[language]}
+						onClick={executeSearch}
+					/>
+				</div>
+			</div>
+		</>
+	);
+};
+
+export default PageNotFound;

--- a/src/views/ErrorBoundary/PageNotFound.scss
+++ b/src/views/ErrorBoundary/PageNotFound.scss
@@ -1,0 +1,22 @@
+.error-container {
+	.error-searchbar {
+		display: block;
+		div.searchString {
+			margin: 0;
+			padding: 0;
+		}
+
+		.button {
+			display: inline-block;
+			width: 20%;
+			margin-right: 1em;
+			margin-left: 1em;
+			top: -1px;
+
+			@media screen and (max-width: 414px) {
+				font-size: 14px;
+				width: 24%;
+			}
+		}
+	}
+}

--- a/support/src/setupProxy.js
+++ b/support/src/setupProxy.js
@@ -153,6 +153,13 @@ const getTermTotalCount = async (req, res, next) => {
 const getTermByIdOrPrettyUrl = async (req, res, next) => {
 	const { dictionary, audience, language, id_or_purl } = req.params;
 	const lookupPurl = id_or_purl.toLowerCase();
+
+	// Return a 500 specifically for an
+	// id or purl requested with foobar
+	if ( lookupPurl === 'foobar') {
+		res.status(500).end();
+	}
+
 	const searchDir = path.join(
 		__dirname,
 		'..',


### PR DESCRIPTION
Closes #148

* Added 404 page
* Updated `ErrorBoundary` to display 404 page for 404 errors matching route `/def/{idOridOrName}`

* Display 404 page for routes not found in app when hosted on react-app-dev.cancer.gov

* Removed console.log, updated  component

* Added page title and metatags

* Updated unit tests for Definition, only trigger definition tracking when prettyURL or termId exists in payload