### PR TITLE
(#164) Add Analytics to Error Page

### DIFF
--- a/cypress/integration/ApiFailurePage.feature
+++ b/cypress/integration/ApiFailurePage.feature
@@ -1,5 +1,30 @@
 Feature: As a user, I need to encounter an error page when a call to the API fails.
 
-    Scenario: User encounters an error page when API fails
-        Given the user is viewing the definition with the pretty url "foobar"
-        Then the user gets an error page that reads "An error occurred. Please try again later."
+  Scenario: Page Load Analytics fires for a 500 error in the app
+		Given "audience" is set to "Patient"
+		And "dictionaryTitle" is set to "NCI Dictionary of Cancer Terms"
+		And "dictionaryName" is set to "Cancer.gov"
+		And "language" is set to "en"
+		And "baseHost" is set to "http://localhost:3000"
+		And "canonicalHost" is set to "https://www.cancer.gov"
+		And "siteName" is set to "National Cancer Institute"
+		And "analyticsChannel" is set to "Publications"
+		And "analyticsPublishedDate" is set to "02/02/2011"
+		When the user is viewing the definition with the pretty url "foobar"
+		And page title on error page is "An error occurred. Please try again later."
+		And browser waits
+		Then there should be an analytics event with the following details
+			| key                                    | value                          |
+			| type                                   | PageLoad                       |
+			| event                                  | GlossaryApp:Load:Error         |
+			| page.audience                          | Patient                        |
+			| page.channel                           | Publications                   |
+			| page.language                          | english                        |
+			| page.metaTitle                         | Errors Occurred                |
+			| page.name                              | www.cancer.gov/def/foobar      |
+			| page.title                             | Errors Occurred                |
+			| page.type                              | nciAppModulePage               |
+			| page.contentGroup                      | NCI Dictionary of Cancer Terms |
+			| page.publishedDate                     | 02/02/2011                     |
+			| page.additionalDetails.analyticsName   | CancerTerms                    |
+			| page.additionalDetails.dictionaryTitle | NCI Dictionary of Cancer Terms |

--- a/cypress/integration/ApiFailureSpanishPage.feature
+++ b/cypress/integration/ApiFailureSpanishPage.feature
@@ -1,8 +1,30 @@
 Feature: As a user, I need to encounter a Spanish error page when a call to the API fails.
 
-    Background:
-        And "language" is set to "es"
-
-    Scenario: User encounters an error page when API fails
-        Given the user is viewing the definition with the pretty url "foobar"
-        Then the user gets an error page that reads "Se produjo un error. Por favor, vuelva a intentar más tarde."
+	Scenario: Page Load Analytics fires for a 500 error in the app for Spanish
+		Given "audience" is set to "Patient"
+		And "dictionaryTitle" is set to "Diccionario de cáncer"
+		And "dictionaryName" is set to "Cancer.gov"
+		And "language" is set to "es"
+		And "baseHost" is set to "http://localhost:3000"
+		And "canonicalHost" is set to "https://www.cancer.gov"
+		And "siteName" is set to "Instituto Nacional del Cáncer"
+		And "analyticsChannel" is set to "Publications - Spanish"
+		And "analyticsPublishedDate" is set to "02/02/2011"
+		When the user is viewing the definition with the pretty url "foobar"
+		And page title on error page is "Se produjo un error. Por favor, vuelva a intentar más tarde."
+		And browser waits
+		Then there should be an analytics event with the following details
+			| key                                    | value                     |
+			| type                                   | PageLoad                  |
+			| event                                  | GlossaryApp:Load:Error    |
+			| page.audience                          | Patient                   |
+			| page.channel                           | Publications - Spanish    |
+			| page.language                          | spanish                   |
+			| page.metaTitle                         | Errors Occurred           |
+			| page.name                              | www.cancer.gov/def/foobar |
+			| page.title                             | Errors Occurred           |
+			| page.type                              | nciAppModulePage          |
+			| page.contentGroup                      | Diccionario de cáncer     |
+			| page.publishedDate                     | 02/02/2011                |
+			| page.additionalDetails.analyticsName   | CancerTerms               |
+			| page.additionalDetails.dictionaryTitle | Diccionario de cáncer     |

--- a/src/hooks/__tests__/customFetch.tests.js
+++ b/src/hooks/__tests__/customFetch.tests.js
@@ -4,8 +4,10 @@ import { ClientContextProvider } from 'react-fetching-library';
 
 import UseCustomQuerySample from '../samples/UseCustomQuery';
 import { useStateValue } from '../../store/store';
+import MockAnalyticsProvider from '../../tracking/mock-analytics-provider'
 import { i18n } from '../../utils';
 import ErrorBoundary from '../../views/ErrorBoundary';
+import { setAudience, setDictionaryName, setLanguage } from '../../services/api/endpoints'
 
 jest.mock('../../store/store');
 
@@ -22,8 +24,26 @@ describe('', () => {
 	});
 
 	test('useCustomQuery example should throw error - English message', async () => {
+		const dictionaryName = 'Cancer.gov';
+		const dictionaryTitle = 'NCI Dictionary of Cancer Terms';
 		const language = 'en';
-		useStateValue.mockReturnValue([{ language }]);
+		setDictionaryName(dictionaryName);
+		setAudience('Patient');
+		setLanguage(language);
+
+		useStateValue.mockReturnValue([
+			{
+				altLanguageDictionaryBasePath: '/diccionario',
+				languageToggleSelector: '#LangList1 a',
+				appId: 'mockAppId',
+				canonicalHost: 'https://example.org',
+				basePath: '/',
+				dictionaryEndpoint: '/',
+				dictionaryName,
+				dictionaryTitle,
+				language,
+			},
+		]);
 		client = {
 			query: async () => ({
 				error: true,
@@ -33,11 +53,13 @@ describe('', () => {
 		};
 		await act(async () => {
 			wrapper = render(
-				<ClientContextProvider client={client}>
-					<ErrorBoundary>
-						<UseCustomQuerySample />
-					</ErrorBoundary>
-				</ClientContextProvider>
+				<MockAnalyticsProvider>
+					<ClientContextProvider client={client}>
+						<ErrorBoundary>
+							<UseCustomQuerySample />
+						</ErrorBoundary>
+					</ClientContextProvider>
+				</MockAnalyticsProvider>
 			);
 		});
 		const { getByText } = wrapper;
@@ -45,8 +67,26 @@ describe('', () => {
 	});
 
 	test('useCustomQuery example should throw error - Spanish message', async () => {
+		const dictionaryName = 'Cancer.gov';
+		const dictionaryTitle = 'Diccionario de cáncer';
 		const language = 'es';
-		useStateValue.mockReturnValue([{ language }]);
+		setDictionaryName(dictionaryName);
+		setAudience('Patient');
+		setLanguage(language);
+
+		useStateValue.mockReturnValue([
+			{
+				altLanguageDictionaryBasePath: '/cancer-terms',
+				languageToggleSelector: '#LangList1 a',
+				appId: 'mockAppId',
+				canonicalHost: 'https://example.org',
+				basePath: '/',
+				dictionaryEndpoint: '/',
+				dictionaryName,
+				dictionaryTitle,
+				language,
+			},
+		]);
 		client = {
 			query: async () => ({
 				error: true,
@@ -56,11 +96,13 @@ describe('', () => {
 		};
 		await act(async () => {
 			wrapper = render(
-				<ClientContextProvider client={client}>
-					<ErrorBoundary>
-						<UseCustomQuerySample />
-					</ErrorBoundary>
-				</ClientContextProvider>
+				<MockAnalyticsProvider>
+					<ClientContextProvider client={client}>
+						<ErrorBoundary>
+							<UseCustomQuerySample />
+						</ErrorBoundary>
+					</ClientContextProvider>
+				</MockAnalyticsProvider>
 			);
 		});
 		const { getByText } = wrapper;
@@ -68,9 +110,27 @@ describe('', () => {
 	});
 
 	test('useCustomQuery example should display content and not throw error', async () => {
-		const language = 'en';
 		const contentMessage = 'Successful API call with content';
-		useStateValue.mockReturnValue([{ language }]);
+		const dictionaryName = 'Cancer.gov';
+		const dictionaryTitle = 'NCI Dictionary of Cancer Terms';
+		const language = 'en';
+		setDictionaryName(dictionaryName);
+		setAudience('Patient');
+		setLanguage(language);
+
+		useStateValue.mockReturnValue([
+			{
+				altLanguageDictionaryBasePath: '/diccionario',
+				languageToggleSelector: '#LangList1 a',
+				appId: 'mockAppId',
+				canonicalHost: 'https://example.org',
+				basePath: '/',
+				dictionaryEndpoint: '/',
+				dictionaryName,
+				dictionaryTitle,
+				language,
+			}
+		]);
 
 		client = {
 			query: async () => ({
@@ -81,11 +141,13 @@ describe('', () => {
 		};
 		await act(async () => {
 			wrapper = render(
-				<ClientContextProvider client={client}>
-					<ErrorBoundary>
-						<UseCustomQuerySample />
-					</ErrorBoundary>
-				</ClientContextProvider>
+				<MockAnalyticsProvider>
+					<ClientContextProvider client={client}>
+						<ErrorBoundary>
+							<UseCustomQuerySample />
+						</ErrorBoundary>
+					</ClientContextProvider>
+				</MockAnalyticsProvider>
 			);
 		});
 		const { getByText } = wrapper;

--- a/src/views/ErrorBoundary/ErrorPage.jsx
+++ b/src/views/ErrorBoundary/ErrorPage.jsx
@@ -1,10 +1,26 @@
-import React from 'react';
+import React, { useEffect } from 'react';
+import { useTracking } from 'react-tracking';
 
 import { useStateValue } from '../../store/store';
 import { i18n } from '../../utils';
 
 const ErrorPage = () => {
-	const [{ language }] = useStateValue();
+	const [{ canonicalHost, language }] = useStateValue();
+	const tracking = useTracking();
+
+	useEffect(() => {
+		const pageTitle = 'Errors Occurred';
+		tracking.trackEvent({
+			event: 'GlossaryApp:Load:Error',
+			metaTitle: pageTitle,
+			name: `${canonicalHost.replace('https://', '')}${
+				window.location.pathname
+			}`,
+			title: pageTitle,
+			type: 'PageLoad',
+		});
+	}, []);
+
 	return (
 		<div className="error-container">
 			<h1>{i18n.errorPageText[language]}</h1>


### PR DESCRIPTION
Closes #164

* Added tracking to ErrorPage
* Updated integrations tests for ApiFailure feature files
* Updated unit tests for customFetch

* Removed commented steps