### PR TITLE
(#151) Fix for term count response breaking home page render in IE11

### DIFF
--- a/src/services/api/buildAxiosRequest.js
+++ b/src/services/api/buildAxiosRequest.js
@@ -25,7 +25,9 @@ export const buildAxiosRequest = (axiosInstance) => async (init, options) => {
 
 	const result = await axiosInstance.request(config);
 	const responseBody =
-		typeof result.data === `object` ? JSON.stringify(result.data) : result.data;
+		typeof result.data === `object`
+			? JSON.stringify(result.data)
+			: result.data.toString();
 	const headers = new Headers();
 
 	Object.entries(result.headers).forEach(function ([key, value]) {

--- a/src/views/Home/IntroText.jsx
+++ b/src/views/Home/IntroText.jsx
@@ -8,7 +8,7 @@ import { useStateValue } from '../../store/store';
 import { formatNumberToThousands, TokenParser } from '../../utils';
 
 const IntroText = () => {
-	const [isIntroTextReplaced, introTextReplaced] = useState(false);
+	const [isIntroTextReplaced, setIsIntroTextReplaced] = useState(false);
 	const [{ dictionaryIntroText }, dispatch] = useStateValue();
 	const termCount = useCustomQuery(getTermCount());
 
@@ -26,7 +26,7 @@ const IntroText = () => {
 					value: TokenParser.replaceTokens(dictionaryIntroText, context),
 				})
 			);
-			introTextReplaced(true);
+			setIsIntroTextReplaced(true);
 		}
 	}, [termCount.payload, dictionaryIntroText, dispatch, isIntroTextReplaced]);
 


### PR DESCRIPTION
Closes #151 .

The term count service is simply returning a number which caused an error to be thrown in IE11.  

In IE11, an error saying invalid character encountered was appearing which we think was IE's way of saying expecting a curly brace.