### PR TITLE
(#177) Keep the searchType wording backwards compatible

### DIFF
--- a/cypress/integration/AppAnalytics/clickEventOnKeywordSearch.feature
+++ b/cypress/integration/AppAnalytics/clickEventOnKeywordSearch.feature
@@ -1,53 +1,53 @@
 Feature: Analytics click event on keyword search
 
-Scenario: When a user clicks on the search button for a starts with search, an analytics click event will be fired.
-  Given "audience" is set to "Patient"
-  And "dictionaryTitle" is set to "NCI Dictionary of Cancer Terms"
-  And "dictionaryName" is set to "Cancer.gov"
-  And "language" is set to "en"
-  And "baseHost" is set to "http://localhost:3000"
-  And "canonicalHost" is set to "https://www.cancer.gov"
-  And "siteName" is set to "National Cancer Institute"
-  And "channel" is set to "Publications"
-  And "analyticsPublishedDate" is set to "02/02/2011"
-  Given the user is viewing the dictionary landing page
-  And the search box has loaded
-  And the user selects the "Starts with" option in the search box
-  And the user enters "metastatic"
-  And the user submits the keyword search
-  Then there should be an analytics event with the following details
-    | key                    | value                           |
-    | type                   | Other                           |
-    | event                  | GlossaryApp:Other:KeywordSearch |
-    | linkName               | TermsDictionarySearch           |
-    | data.dictionaryTitle   | NCI Dictionary of Cancer Terms  |
-    | data.analyticsName     | CancerTerms                     |
-    | data.page              | app_load                        |
-    | data.searchTerm        | metastatic                      |
-    | data.searchType        | Begins                          |
+	Scenario: When a user clicks on the search button for a starts with search, an analytics click event will be fired.
+		Given "audience" is set to "Patient"
+		And "dictionaryTitle" is set to "NCI Dictionary of Cancer Terms"
+		And "dictionaryName" is set to "Cancer.gov"
+		And "language" is set to "en"
+		And "baseHost" is set to "http://localhost:3000"
+		And "canonicalHost" is set to "https://www.cancer.gov"
+		And "siteName" is set to "National Cancer Institute"
+		And "channel" is set to "Publications"
+		And "analyticsPublishedDate" is set to "02/02/2011"
+		Given the user is viewing the dictionary landing page
+		And the search box has loaded
+		And the user selects the "Starts with" option in the search box
+		And the user enters "metastatic"
+		And the user submits the keyword search
+		Then there should be an analytics event with the following details
+			| key                  | value                           |
+			| type                 | Other                           |
+			| event                | GlossaryApp:Other:KeywordSearch |
+			| linkName             | TermsDictionarySearch           |
+			| data.dictionaryTitle | NCI Dictionary of Cancer Terms  |
+			| data.analyticsName   | CancerTerms                     |
+			| data.page            | app_load                        |
+			| data.searchTerm      | metastatic                      |
+			| data.searchType      | starts with                     |
 
-Scenario: When a user clicks on the search button for a contains search, an analytics click event will be fired.
-  Given the user is viewing the dictionary landing page
-  Given "audience" is set to "Patient"
-  And "dictionaryTitle" is set to "NCI Dictionary of Cancer Terms"
-  And "dictionaryName" is set to "Cancer.gov"
-  And "language" is set to "en"
-  And "baseHost" is set to "http://localhost:3000"
-  And "canonicalHost" is set to "https://www.cancer.gov"
-  And "siteName" is set to "National Cancer Institute"
-  And "channel" is set to "Publications"
-  And "analyticsPublishedDate" is set to "02/02/2011"
-  And the search box has loaded
-  And the user selects the "Contains" option in the search box
-  And the user enters "metastatic"
-  And the user submits the keyword search
-  Then there should be an analytics event with the following details
-    | key                    | value                           |
-    | type                   | Other                           |
-    | event                  | GlossaryApp:Other:KeywordSearch |
-    | linkName               | TermsDictionarySearch           |
-    | data.dictionaryTitle   | NCI Dictionary of Cancer Terms  |
-    | data.analyticsName     | CancerTerms                     |
-    | data.page              | app_load                        |
-    | data.searchTerm        | metastatic                      |
-    | data.searchType        | Contains                        |
+	Scenario: When a user clicks on the search button for a contains search, an analytics click event will be fired.
+		Given the user is viewing the dictionary landing page
+		Given "audience" is set to "Patient"
+		And "dictionaryTitle" is set to "NCI Dictionary of Cancer Terms"
+		And "dictionaryName" is set to "Cancer.gov"
+		And "language" is set to "en"
+		And "baseHost" is set to "http://localhost:3000"
+		And "canonicalHost" is set to "https://www.cancer.gov"
+		And "siteName" is set to "National Cancer Institute"
+		And "channel" is set to "Publications"
+		And "analyticsPublishedDate" is set to "02/02/2011"
+		And the search box has loaded
+		And the user selects the "Contains" option in the search box
+		And the user enters "metastatic"
+		And the user submits the keyword search
+		Then there should be an analytics event with the following details
+			| key                  | value                           |
+			| type                 | Other                           |
+			| event                | GlossaryApp:Other:KeywordSearch |
+			| linkName             | TermsDictionarySearch           |
+			| data.dictionaryTitle | NCI Dictionary of Cancer Terms  |
+			| data.analyticsName   | CancerTerms                     |
+			| data.page            | app_load                        |
+			| data.searchTerm      | metastatic                      |
+			| data.searchType      | contains                        |

--- a/src/components/molecules/search/Search.jsx
+++ b/src/components/molecules/search/Search.jsx
@@ -3,13 +3,18 @@ import PropTypes from 'prop-types';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
 
 import { Autocomplete, Radio } from '../../atomic';
-import { searchMatchType, testIds } from '../../../constants';
+import {
+	searchMatchType,
+	searchMatchTypeAnalyticsMap,
+	testIds,
+} from '../../../constants';
 import { useAppPaths, useCustomQuery } from '../../../hooks';
 import { getAutoSuggestResults } from '../../../services/api/actions';
 import { useStateValue } from '../../../store/store';
 import { useTracking } from 'react-tracking';
 import {
 	emboldenSubstring,
+	getKeyValueFromObject,
 	getKeyValueFromQueryString,
 	i18n,
 	matchItemToTerm,
@@ -50,9 +55,10 @@ const Search = ({ autoSuggestLimit = 10 }) => {
 
 	const trackSubmit = () => {
 		const searchType =
-			selectedOption && selectedOption === searchMatchType.contains
-				? 'Contains'
-				: 'Begins';
+			selectedOption &&
+			getKeyValueFromObject(selectedOption, searchMatchTypeAnalyticsMap)
+				? getKeyValueFromObject(selectedOption, searchMatchTypeAnalyticsMap)
+				: searchMatchTypeAnalyticsMap[searchMatchType.beginsWith];
 		tracking.trackEvent({
 			type: 'Other',
 			event: 'GlossaryApp:Other:KeywordSearch',

--- a/src/constants.js
+++ b/src/constants.js
@@ -11,6 +11,11 @@ export const searchMatchType = {
 	contains: 'Contains',
 };
 
+export const searchMatchTypeAnalyticsMap = {
+	[searchMatchType.beginsWith]: 'starts with',
+	[searchMatchType.contains]: 'contains',
+};
+
 // Test Ids
 export const testIds = {
 	AUTO_SUGGEST_OPTIONS: 'tid-auto-suggest-options',

--- a/src/utils/__tests__/objects.tests.js
+++ b/src/utils/__tests__/objects.tests.js
@@ -1,0 +1,15 @@
+import { getKeyValueFromObject } from '../objects';
+
+const testObject = {
+	termId: 467848,
+	termName: 'methodology',
+};
+
+describe('getKeyValueFromObject', () => {
+	test(`should retrieve termId value ${testObject.termId} from test object`, () => {
+		expect(getKeyValueFromObject('termId', testObject)).toEqual(467848);
+	});
+	test('should return "undefined" for key that does not exist in test object', () => {
+		expect(getKeyValueFromObject('termKey', testObject)).toEqual(undefined);
+	});
+});

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -3,6 +3,7 @@ export { i18n } from './i18n';
 export { getProductTestBase } from './getProductTestBase';
 export { formatNumberToThousands } from './number';
 export { matchItemToTerm } from './matchItemToTerm';
+export { getKeyValueFromObject } from './objects';
 export { TokenParser } from './replaceTokens';
 export { emboldenSubstring } from './strings';
 export { getKeyValueFromQueryString } from './url';

--- a/src/utils/objects.js
+++ b/src/utils/objects.js
@@ -1,0 +1,9 @@
+export const getKeyValueFromObject = ( key, obj ) => {
+	let retValue;
+	Object.keys(obj).forEach( thisKey => {
+		if( thisKey === key ) {
+			retValue = obj[key];
+		}
+	});
+	return retValue;
+};


### PR DESCRIPTION
Closes #177

* Replaced `data.searchType` analytics for both "Contains" and "Begin" with "contains" and "starts with" respectively