### PR TITLE
Ticket #206 Redirect to PrettyUrl is missing '?redirect=true' query parameter

### DIFF
--- a/cypress/integration/PrettyUrlRedirect.feature
+++ b/cypress/integration/PrettyUrlRedirect.feature
@@ -3,3 +3,4 @@ Feature: Redirect to Pretty URL Definition Page
 Scenario: As a user, if my term's page URL contains an ID, I would like to be redirected to the term’s page with a pretty URL name.
   Given the user is viewing the definition with the ID "44058"
   Then the user is redirected to "/def/metastatic"
+  And the system appends '?redirect=true' to the URL

--- a/cypress/integration/common/index.js
+++ b/cypress/integration/common/index.js
@@ -51,6 +51,11 @@ Given('user is on landing Genetics Terms page', () => {
 	cy.visit(baseURL);
 });
 
+And('the system appends {string} to the URL', (a) => {
+	cy.location('search').should('eq',a)
+
+});
+
 Given(
 	'the user is viewing the definition with the pretty url {string}',
 	(a) => {
@@ -788,3 +793,4 @@ And('the user enters {string}', (userText) => {
 And('the user submits the keyword search', () => {
 	cy.get('#btnSearch').click();
 });
+

--- a/src/views/Definition/Definition.jsx
+++ b/src/views/Definition/Definition.jsx
@@ -87,7 +87,8 @@ const Definition = () => {
 
 			// redirect to URL with pretty URL name if ID is used
 			if (payload.prettyUrlName && idOrName.match(/^[0-9]+$/) != null) {
-				navigate(DefinitionPath({ idOrName: payload.prettyUrlName }));
+				const redirectedURL = `${payload.prettyUrlName}?redirect=true`;
+				navigate(DefinitionPath({ idOrName: redirectedURL }));
 				return;
 			}
 

--- a/src/views/Definition/__tests__/Definition.PrettyURLRedirect.test.js
+++ b/src/views/Definition/__tests__/Definition.PrettyURLRedirect.test.js
@@ -90,7 +90,7 @@ test('Ensure page is redirected to the definition page with a pretty URL name', 
 
 	const expectedLocationObject = {
 		pathname: '/def/a33',
-		search: '',
+		search: '?redirect=true',
 		hash: '',
 		state: null,
 		key: expect.any(String),


### PR DESCRIPTION
Closes #206
Added '?redirect=true' query parameter to prettyURL for /def/46722
- edited Definition.jsx by adding the ?redirect=true part of the query
- edited BasicTermPage.feature by adding redirect Scenario
- edited index.js accordingly