### PR TITLE
(#242) Fixed Pa11y Issue

### DIFF
--- a/.pa11yci
+++ b/.pa11yci
@@ -15,5 +15,12 @@
     "http://localhost:3000/def/acrochordon?cfg=2",
     "http://localhost:3000/def/acrochordon?cfg=3",
     "http://localhost:3000/def/antioncogen?cfg=3"
-  ]
+  ],
+		"chromeLaunchConfig": {
+			"args": [
+				"--no-sandbox",
+				"--disable-setuid-sandbox",
+				"--disable-dev-shm-usage"
+			]
+		}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2724,6 +2724,16 @@
 			"integrity": "sha512-FA/BWv8t8ZWJ+gEOnLLd8ygxH/2UFbAvgEonyfN6yWGLKc7zVjbpl2Y4CTjid9h2RfgPP6SEt6uHwEOply00yw==",
 			"dev": true
 		},
+		"@types/yauzl": {
+			"version": "2.10.0",
+			"resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.0.tgz",
+			"integrity": "sha512-Cn6WYCm0tXv8p6k+A8PvbDG763EDpBoTzHdA+Q/MF6H3sapGjCm9NzoaJncJS9tUKSuCoDs9XHxYYsQDgxR6kw==",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"@types/node": "*"
+			}
+		},
 		"@typescript-eslint/eslint-plugin": {
 			"version": "4.15.2",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.15.2.tgz",
@@ -3273,12 +3283,12 @@
 			}
 		},
 		"agent-base": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
-			"integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+			"integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
 			"dev": true,
 			"requires": {
-				"es6-promisify": "^5.0.0"
+				"debug": "4"
 			}
 		},
 		"aggregate-error": {
@@ -3976,9 +3986,9 @@
 			"dev": true
 		},
 		"axe-core": {
-			"version": "3.5.5",
-			"resolved": "https://registry.npmjs.org/axe-core/-/axe-core-3.5.5.tgz",
-			"integrity": "sha512-5P0QZ6J5xGikH780pghEdbEKijCTrruK9KxtPZCFWUpef0f6GipO+xEZ5GKCb020mmqgbiNO6TcA55CriL784Q==",
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.4.3.tgz",
+			"integrity": "sha512-32+ub6kkdhhWick/UjvEwRchgoetXqTK14INLqbGm5U2TzBkBNF3nQtLYm8ovxSkQWArjEQvftCKryjZaATu3w==",
 			"dev": true
 		},
 		"axios": {
@@ -4613,14 +4623,23 @@
 			"dev": true
 		},
 		"bfj": {
-			"version": "4.2.4",
-			"resolved": "https://registry.npmjs.org/bfj/-/bfj-4.2.4.tgz",
-			"integrity": "sha1-hfeyNoPCr9wVhgOEotHD+sgO0zo=",
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/bfj/-/bfj-7.0.2.tgz",
+			"integrity": "sha512-+e/UqUzwmzJamNF50tBV6tZPTORow7gQ96iFow+8b562OdMpEK0BcJEq2OSPEDmAbSMBQ7PKZ87ubFkgxpYWgw==",
 			"dev": true,
 			"requires": {
-				"check-types": "^7.3.0",
-				"hoopy": "^0.1.2",
-				"tryer": "^1.0.0"
+				"bluebird": "^3.5.5",
+				"check-types": "^11.1.1",
+				"hoopy": "^0.1.4",
+				"tryer": "^1.0.1"
+			},
+			"dependencies": {
+				"bluebird": {
+					"version": "3.7.2",
+					"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+					"integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+					"dev": true
+				}
 			}
 		},
 		"big.js": {
@@ -4642,6 +4661,30 @@
 			"optional": true,
 			"requires": {
 				"file-uri-to-path": "1.0.0"
+			}
+		},
+		"bl": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+			"integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+			"dev": true,
+			"requires": {
+				"buffer": "^5.5.0",
+				"inherits": "^2.0.4",
+				"readable-stream": "^3.4.0"
+			},
+			"dependencies": {
+				"readable-stream": {
+					"version": "3.6.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+					"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+					"dev": true,
+					"requires": {
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
+					}
+				}
 			}
 		},
 		"blob-util": {
@@ -5320,76 +5363,175 @@
 			"dev": true
 		},
 		"check-types": {
-			"version": "7.4.0",
-			"resolved": "https://registry.npmjs.org/check-types/-/check-types-7.4.0.tgz",
-			"integrity": "sha512-YbulWHdfP99UfZ73NcUDlNJhEIDgm9Doq9GhpyXbF+7Aegi3CVV7qqMCKTTqJxlvEvnQBp9IA+dxsGN6xK/nSg==",
+			"version": "11.1.2",
+			"resolved": "https://registry.npmjs.org/check-types/-/check-types-11.1.2.tgz",
+			"integrity": "sha512-tzWzvgePgLORb9/3a0YenggReLKAIb2owL03H2Xdoe5pKcUyWRSEQ8xfCar8t2SIAuEDwtmx2da1YB52YuHQMQ==",
 			"dev": true
 		},
 		"cheerio": {
-			"version": "1.0.0-rc.3",
-			"resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.3.tgz",
-			"integrity": "sha512-0td5ijfUPuubwLUu0OBoe98gZj8C/AA+RW3v67GPlGOrvxWjZmBXiBCRU+I8VEiNyJzjth40POfHiz2RB3gImA==",
+			"version": "1.0.0-rc.12",
+			"resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.12.tgz",
+			"integrity": "sha512-VqR8m68vM46BNnuZ5NtnGBKIE/DfN0cRIzg9n40EIq9NOv90ayxLBXA8fXC5gquFRGJSTRqBq25Jt2ECLR431Q==",
 			"dev": true,
 			"requires": {
-				"css-select": "~1.2.0",
-				"dom-serializer": "~0.1.1",
-				"entities": "~1.1.1",
-				"htmlparser2": "^3.9.1",
-				"lodash": "^4.15.0",
-				"parse5": "^3.0.1"
+				"cheerio-select": "^2.1.0",
+				"dom-serializer": "^2.0.0",
+				"domhandler": "^5.0.3",
+				"domutils": "^3.0.1",
+				"htmlparser2": "^8.0.1",
+				"parse5": "^7.0.0",
+				"parse5-htmlparser2-tree-adapter": "^7.0.0"
 			},
 			"dependencies": {
-				"css-select": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
-					"integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
+				"dom-serializer": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+					"integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
 					"dev": true,
 					"requires": {
-						"boolbase": "~1.0.0",
-						"css-what": "2.1",
-						"domutils": "1.5.1",
-						"nth-check": "~1.0.1"
+						"domelementtype": "^2.3.0",
+						"domhandler": "^5.0.2",
+						"entities": "^4.2.0"
 					}
 				},
-				"css-what": {
-					"version": "2.1.3",
-					"resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.3.tgz",
-					"integrity": "sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg==",
+				"domelementtype": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+					"integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
 					"dev": true
 				},
-				"dom-serializer": {
-					"version": "0.1.1",
-					"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.1.tgz",
-					"integrity": "sha512-l0IU0pPzLWSHBcieZbpOKgkIn3ts3vAh7ZuFyXNwJxJXk/c4Gwj9xaTJwIDVQCXawWD0qb3IzMGH5rglQaO0XA==",
+				"domhandler": {
+					"version": "5.0.3",
+					"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+					"integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
 					"dev": true,
 					"requires": {
-						"domelementtype": "^1.3.0",
-						"entities": "^1.1.1"
+						"domelementtype": "^2.3.0"
 					}
 				},
 				"domutils": {
-					"version": "1.5.1",
-					"resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
-					"integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/domutils/-/domutils-3.0.1.tgz",
+					"integrity": "sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==",
 					"dev": true,
 					"requires": {
-						"dom-serializer": "0",
-						"domelementtype": "1"
+						"dom-serializer": "^2.0.0",
+						"domelementtype": "^2.3.0",
+						"domhandler": "^5.0.1"
 					}
 				},
 				"entities": {
-					"version": "1.1.2",
-					"resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
-					"integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
+					"version": "4.4.0",
+					"resolved": "https://registry.npmjs.org/entities/-/entities-4.4.0.tgz",
+					"integrity": "sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA==",
 					"dev": true
 				},
-				"parse5": {
-					"version": "3.0.3",
-					"resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.3.tgz",
-					"integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
+				"htmlparser2": {
+					"version": "8.0.1",
+					"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.1.tgz",
+					"integrity": "sha512-4lVbmc1diZC7GUJQtRQ5yBAeUCL1exyMwmForWkRLnwyzWBFxN633SALPMGYaWZvKe9j1pRZJpauvmxENSp/EA==",
 					"dev": true,
 					"requires": {
-						"@types/node": "*"
+						"domelementtype": "^2.3.0",
+						"domhandler": "^5.0.2",
+						"domutils": "^3.0.1",
+						"entities": "^4.3.0"
+					}
+				},
+				"parse5": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/parse5/-/parse5-7.0.0.tgz",
+					"integrity": "sha512-y/t8IXSPWTuRZqXc0ajH/UwDj4mnqLEbSttNbThcFhGrZuOyoyvNBO85PBp2jQa55wY9d07PBNjsK8ZP3K5U6g==",
+					"dev": true,
+					"requires": {
+						"entities": "^4.3.0"
+					}
+				}
+			}
+		},
+		"cheerio-select": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
+			"integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
+			"dev": true,
+			"requires": {
+				"boolbase": "^1.0.0",
+				"css-select": "^5.1.0",
+				"css-what": "^6.1.0",
+				"domelementtype": "^2.3.0",
+				"domhandler": "^5.0.3",
+				"domutils": "^3.0.1"
+			},
+			"dependencies": {
+				"css-select": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
+					"integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
+					"dev": true,
+					"requires": {
+						"boolbase": "^1.0.0",
+						"css-what": "^6.1.0",
+						"domhandler": "^5.0.2",
+						"domutils": "^3.0.1",
+						"nth-check": "^2.0.1"
+					}
+				},
+				"css-what": {
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
+					"integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==",
+					"dev": true
+				},
+				"dom-serializer": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+					"integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+					"dev": true,
+					"requires": {
+						"domelementtype": "^2.3.0",
+						"domhandler": "^5.0.2",
+						"entities": "^4.2.0"
+					}
+				},
+				"domelementtype": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+					"integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+					"dev": true
+				},
+				"domhandler": {
+					"version": "5.0.3",
+					"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+					"integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+					"dev": true,
+					"requires": {
+						"domelementtype": "^2.3.0"
+					}
+				},
+				"domutils": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/domutils/-/domutils-3.0.1.tgz",
+					"integrity": "sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==",
+					"dev": true,
+					"requires": {
+						"dom-serializer": "^2.0.0",
+						"domelementtype": "^2.3.0",
+						"domhandler": "^5.0.1"
+					}
+				},
+				"entities": {
+					"version": "4.4.0",
+					"resolved": "https://registry.npmjs.org/entities/-/entities-4.4.0.tgz",
+					"integrity": "sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA==",
+					"dev": true
+				},
+				"nth-check": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+					"integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+					"dev": true,
+					"requires": {
+						"boolbase": "^1.0.0"
 					}
 				}
 			}
@@ -5413,6 +5555,12 @@
 				"readdirp": "^2.2.1",
 				"upath": "^1.1.1"
 			}
+		},
+		"chownr": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+			"integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+			"dev": true
 		},
 		"chrome-trace-event": {
 			"version": "1.0.2",
@@ -7261,6 +7409,12 @@
 				"minimist": "^1.1.1"
 			}
 		},
+		"devtools-protocol": {
+			"version": "0.0.869402",
+			"resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.869402.tgz",
+			"integrity": "sha512-VvlVYY+VDJe639yHs5PHISzdWTLL3Aw8rO4cvUtwvoxFd6FHbE4OpHHcde52M6096uYYazAmd4l0o5VuFRO2WA==",
+			"dev": true
+		},
 		"diff": {
 			"version": "3.5.0",
 			"resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
@@ -7605,6 +7759,12 @@
 			"integrity": "sha512-D9f7V0JSRwIxlRI2mjMqufDrRDnx8p+eEOz7aUM9SuvF8gsBzra0/6tbjl1m8eQHrZlYj6PxqE00hZ1SAIKPLw==",
 			"dev": true
 		},
+		"envinfo": {
+			"version": "7.8.1",
+			"resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.8.1.tgz",
+			"integrity": "sha512-/o+BXHmB7ocbHEAs6F2EnG0ogybVVUdkRunTT2glZU9XAaGmhqskrvKwqXuDfNjEO0LZKWdejEEpnq8aM0tOaw==",
+			"dev": true
+		},
 		"errno": {
 			"version": "0.1.7",
 			"resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
@@ -7694,15 +7854,6 @@
 			"version": "4.2.8",
 			"resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
 			"integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
-		},
-		"es6-promisify": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
-			"integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
-			"dev": true,
-			"requires": {
-				"es6-promise": "^4.0.3"
-			}
 		},
 		"es6-symbol": {
 			"version": "3.1.3",
@@ -9844,6 +9995,12 @@
 			"integrity": "sha512-Xu2Qh8yqYuDhQGOhD5iJGninErSfI9A3FrriD3tjUgV5VbJFeH8vfgZ9HnC6jWN80QDVNQK5vmxRAmEAp7Mevw==",
 			"dev": true
 		},
+		"fs-constants": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+			"integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+			"dev": true
+		},
 		"fs-extra": {
 			"version": "8.1.0",
 			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
@@ -10879,6 +11036,33 @@
 				"minimalistic-crypto-utils": "^1.0.1"
 			}
 		},
+		"hogan.js": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/hogan.js/-/hogan.js-3.0.2.tgz",
+			"integrity": "sha512-RqGs4wavGYJWE07t35JQccByczmNUXQT0E12ZYV1VKYu5UiAU9lsos/yBAcf840+zrUQQxgVduCR5/B8nNtibg==",
+			"dev": true,
+			"requires": {
+				"mkdirp": "0.3.0",
+				"nopt": "1.0.10"
+			},
+			"dependencies": {
+				"mkdirp": {
+					"version": "0.3.0",
+					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
+					"integrity": "sha512-OHsdUcVAQ6pOtg5JYWpCBo9W/GySVuwvP9hueRMW7UqshC0tbfzLv8wjySTPm3tfUZ/21CE9E1pJagOA91Pxew==",
+					"dev": true
+				},
+				"nopt": {
+					"version": "1.0.10",
+					"resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+					"integrity": "sha512-NWmpvLSqUrgrAC9HCuxEvb+PSloHpqVu+FqcO4eeF2h5qYRhA7ev6KvelyQAKtegUbC6RypJnlEOhd8vloNKYg==",
+					"dev": true,
+					"requires": {
+						"abbrev": "1"
+					}
+				}
+			}
+		},
 		"hoist-non-react-statics": {
 			"version": "3.3.2",
 			"resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
@@ -11112,24 +11296,13 @@
 			"dev": true
 		},
 		"https-proxy-agent": {
-			"version": "2.2.4",
-			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
-			"integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+			"integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
 			"dev": true,
 			"requires": {
-				"agent-base": "^4.3.0",
-				"debug": "^3.1.0"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "3.2.6",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-					"dev": true,
-					"requires": {
-						"ms": "^2.1.1"
-					}
-				}
+				"agent-base": "6",
+				"debug": "4"
 			}
 		},
 		"human-signals": {
@@ -13841,6 +14014,12 @@
 				"minimist": "^1.2.5"
 			}
 		},
+		"mkdirp-classic": {
+			"version": "0.5.3",
+			"resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+			"integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+			"dev": true
+		},
 		"module-deps": {
 			"version": "6.2.3",
 			"resolved": "https://registry.npmjs.org/module-deps/-/module-deps-6.2.3.tgz",
@@ -14007,10 +14186,37 @@
 			}
 		},
 		"node-fetch": {
-			"version": "2.6.1",
-			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-			"integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
-			"dev": true
+			"version": "2.6.7",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+			"integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+			"dev": true,
+			"requires": {
+				"whatwg-url": "^5.0.0"
+			},
+			"dependencies": {
+				"tr46": {
+					"version": "0.0.3",
+					"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+					"integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+					"dev": true
+				},
+				"webidl-conversions": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+					"integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+					"dev": true
+				},
+				"whatwg-url": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+					"integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+					"dev": true,
+					"requires": {
+						"tr46": "~0.0.3",
+						"webidl-conversions": "^3.0.0"
+					}
+				}
+			}
 		},
 		"node-forge": {
 			"version": "0.10.0",
@@ -15089,21 +15295,10 @@
 			}
 		},
 		"p-timeout": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-2.0.1.tgz",
-			"integrity": "sha512-88em58dDVB/KzPEx1X0N3LwFfYZPyDc4B6eF38M1rk9VTZMbxXXgjugz8mmwpS9Ox4BDZ+t6t3QP5+/gazweIA==",
-			"dev": true,
-			"requires": {
-				"p-finally": "^1.0.0"
-			},
-			"dependencies": {
-				"p-finally": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-					"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
-					"dev": true
-				}
-			}
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-4.1.0.tgz",
+			"integrity": "sha512-+/wmHtzJuWii1sXn3HCuH/FTwGhrp4tmJTxSKJbfS+vkipci6osxXM5mY0jUiRzWKMTgUT8l7HFbeSwZAynqHw==",
+			"dev": true
 		},
 		"p-try": {
 			"version": "1.0.0",
@@ -15112,94 +15307,100 @@
 			"dev": true
 		},
 		"pa11y": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/pa11y/-/pa11y-5.3.0.tgz",
-			"integrity": "sha512-g1cVpmRQQXClTZYbx4JC+FqCu6AfM9K3px2TPb2NY9JrorxYiInOKQCa9eF6URjY//bDkQmkn65rTWmbwTC07A==",
+			"version": "6.1.1",
+			"resolved": "https://registry.npmjs.org/pa11y/-/pa11y-6.1.1.tgz",
+			"integrity": "sha512-2NzqA3D9CUlDWj8WuOI4fM2P0qM1d/IUxsRRpzCOfDT5eMR1oEgmUwW2TAk+f90ff/GVck0BewdYT4et4BANew==",
 			"dev": true,
 			"requires": {
-				"commander": "^3.0.2",
-				"node.extend": "^2.0.2",
-				"p-timeout": "^2.0.1",
-				"pa11y-reporter-cli": "^1.0.1",
-				"pa11y-reporter-csv": "^1.0.0",
-				"pa11y-reporter-json": "^1.0.0",
-				"pa11y-runner-axe": "^1.0.1",
-				"pa11y-runner-htmlcs": "^1.2.0",
-				"puppeteer": "^1.13.0",
-				"semver": "^5.6.0"
+				"axe-core": "^4.0.2",
+				"bfj": "~7.0.2",
+				"commander": "~8.0.0",
+				"envinfo": "~7.8.1",
+				"hogan.js": "^3.0.2",
+				"html_codesniffer": "^2.5.1",
+				"kleur": "~4.1.4",
+				"node.extend": "~2.0.2",
+				"p-timeout": "~4.1.0",
+				"puppeteer": "~9.1.1",
+				"semver": "~7.3.5"
 			},
 			"dependencies": {
 				"commander": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-3.0.2.tgz",
-					"integrity": "sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow==",
+					"version": "8.0.0",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-8.0.0.tgz",
+					"integrity": "sha512-Xvf85aAtu6v22+E5hfVoLHqyul/jyxh91zvqk/ioJTQuJR7Z78n7H558vMPKanPSRgIEeZemT92I2g9Y8LPbSQ==",
 					"dev": true
 				},
+				"kleur": {
+					"version": "4.1.5",
+					"resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+					"integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+					"dev": true
+				},
+				"lru-cache": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+					"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+					"dev": true,
+					"requires": {
+						"yallist": "^4.0.0"
+					}
+				},
 				"semver": {
-					"version": "5.7.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+					"version": "7.3.7",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+					"integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+					"dev": true,
+					"requires": {
+						"lru-cache": "^6.0.0"
+					}
+				},
+				"yallist": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
 					"dev": true
 				}
 			}
 		},
 		"pa11y-ci": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/pa11y-ci/-/pa11y-ci-2.4.0.tgz",
-			"integrity": "sha512-0TOR9CfOTJNO7TpmYfPRxbNZWs6tF/iCk/R+j40kmDlEInLT+my3MHdYhDwC3OjRczaQiRgR3y7y7QqAGENJpw==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/pa11y-ci/-/pa11y-ci-3.0.1.tgz",
+			"integrity": "sha512-DUtEIhEG3Ofds7qRuplq0DdCb9doILRlzcRctFNzo4QUNmVy4iZfM3u51A9cqoPo2irCJZoo5BzfiFrcriY2IQ==",
 			"dev": true,
 			"requires": {
 				"async": "~2.6.3",
-				"chalk": "~1.1.3",
-				"cheerio": "~1.0.0-rc.3",
-				"commander": "~2.20.3",
+				"cheerio": "~1.0.0-rc.10",
+				"commander": "~6.2.1",
 				"globby": "~6.1.0",
-				"lodash": "~4.17.20",
-				"node-fetch": "~2.6.0",
-				"pa11y": "~5.3.0",
+				"kleur": "~4.1.4",
+				"lodash": "~4.17.21",
+				"node-fetch": "~2.6.1",
+				"pa11y": "~6.1.0",
 				"protocolify": "~3.0.0",
-				"puppeteer": "~1.20.0",
+				"puppeteer": "~9.1.1",
 				"wordwrap": "~1.0.0"
 			},
 			"dependencies": {
-				"ansi-styles": {
-					"version": "2.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-					"dev": true
-				},
 				"async": {
-					"version": "2.6.3",
-					"resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-					"integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+					"version": "2.6.4",
+					"resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+					"integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
 					"dev": true,
 					"requires": {
 						"lodash": "^4.17.14"
 					}
 				},
-				"chalk": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^2.2.1",
-						"escape-string-regexp": "^1.0.2",
-						"has-ansi": "^2.0.0",
-						"strip-ansi": "^3.0.0",
-						"supports-color": "^2.0.0"
-					}
-				},
 				"commander": {
-					"version": "2.20.3",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-					"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+					"version": "6.2.1",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+					"integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
 					"dev": true
 				},
 				"globby": {
 					"version": "6.1.0",
 					"resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
-					"integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
+					"integrity": "sha512-KVbFv2TQtbzCoxAnfD6JcHZTYCzyliEaaeM/gH8qQdkKr5s0OP9scEgvdcngyk7AVdY6YVW/TJHd+lQ/Df3Daw==",
 					"dev": true,
 					"requires": {
 						"array-union": "^1.0.1",
@@ -15209,60 +15410,24 @@
 						"pinkie-promise": "^2.0.0"
 					}
 				},
+				"kleur": {
+					"version": "4.1.5",
+					"resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+					"integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+					"dev": true
+				},
+				"lodash": {
+					"version": "4.17.21",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+					"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+					"dev": true
+				},
 				"pify": {
 					"version": "2.3.0",
 					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+					"integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
 					"dev": true
 				}
-			}
-		},
-		"pa11y-reporter-cli": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/pa11y-reporter-cli/-/pa11y-reporter-cli-1.0.1.tgz",
-			"integrity": "sha512-k+XPl5pBU2R1J6iagGv/GpN/dP7z2cX9WXqO0ALpBwHlHN3ZSukcHCOhuLMmkOZNvufwsvobaF5mnaZxT70YyA==",
-			"dev": true,
-			"requires": {
-				"chalk": "^2.1.0"
-			}
-		},
-		"pa11y-reporter-csv": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/pa11y-reporter-csv/-/pa11y-reporter-csv-1.0.0.tgz",
-			"integrity": "sha512-S2gFgbAvONBzAVsVbF8zsYabszrzj7SKhQxrEbw19zF0OFI8wCWn8dFywujYYkg674rmyjweSxSdD+kHTcx4qA==",
-			"dev": true
-		},
-		"pa11y-reporter-json": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/pa11y-reporter-json/-/pa11y-reporter-json-1.0.0.tgz",
-			"integrity": "sha512-EdLrzh1hyZ8DudCSSrcakgtsHDiSsYNsWLSoEAo1JnFTIK8hYpD7vL+xgd0u+LXDxz9wLLFnckdubpklaRpl/w==",
-			"dev": true,
-			"requires": {
-				"bfj": "^4.2.3"
-			}
-		},
-		"pa11y-runner-axe": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/pa11y-runner-axe/-/pa11y-runner-axe-1.0.2.tgz",
-			"integrity": "sha512-HMw5kQZz16vS5Bhe067esgeuULNzFYP4ixOFAHxOurwGDptlyc2OqH6zfUuK4szB9tbgb5F23v3qz9hCbkGRpw==",
-			"dev": true,
-			"requires": {
-				"axe-core": "^3.5.1"
-			}
-		},
-		"pa11y-runner-htmlcs": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/pa11y-runner-htmlcs/-/pa11y-runner-htmlcs-1.2.0.tgz",
-			"integrity": "sha512-uf0wEsoeRfyALXVcZeDadV7ot7pE6JZ3EZwbspwmyXW30ahjCClAfE/FtaNo1y2Mlxx5J9ui1sW2YzhHXocV5g==",
-			"dev": true,
-			"requires": {
-				"html_codesniffer": "^2.4.1"
 			}
 		},
 		"package-hash": {
@@ -15368,6 +15533,48 @@
 			"resolved": "https://registry.npmjs.org/parse5/-/parse5-4.0.0.tgz",
 			"integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA==",
 			"dev": true
+		},
+		"parse5-htmlparser2-tree-adapter": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.0.0.tgz",
+			"integrity": "sha512-B77tOZrqqfUfnVcOrUvfdLbz4pu4RopLD/4vmu3HUPswwTA8OH0EMW9BlWR2B0RCoiZRAHEUu7IxeP1Pd1UU+g==",
+			"dev": true,
+			"requires": {
+				"domhandler": "^5.0.2",
+				"parse5": "^7.0.0"
+			},
+			"dependencies": {
+				"domelementtype": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+					"integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+					"dev": true
+				},
+				"domhandler": {
+					"version": "5.0.3",
+					"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+					"integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+					"dev": true,
+					"requires": {
+						"domelementtype": "^2.3.0"
+					}
+				},
+				"entities": {
+					"version": "4.4.0",
+					"resolved": "https://registry.npmjs.org/entities/-/entities-4.4.0.tgz",
+					"integrity": "sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA==",
+					"dev": true
+				},
+				"parse5": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/parse5/-/parse5-7.0.0.tgz",
+					"integrity": "sha512-y/t8IXSPWTuRZqXc0ajH/UwDj4mnqLEbSttNbThcFhGrZuOyoyvNBO85PBp2jQa55wY9d07PBNjsK8ZP3K5U6g==",
+					"dev": true,
+					"requires": {
+						"entities": "^4.3.0"
+					}
+				}
+			}
 		},
 		"parseurl": {
 			"version": "1.3.3",
@@ -16924,29 +17131,109 @@
 			"dev": true
 		},
 		"puppeteer": {
-			"version": "1.20.0",
-			"resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-1.20.0.tgz",
-			"integrity": "sha512-bt48RDBy2eIwZPrkgbcwHtb51mj2nKvHOPMaSH2IsWiv7lOG9k9zhaRzpDZafrk05ajMc3cu+lSQYYOfH2DkVQ==",
+			"version": "9.1.1",
+			"resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-9.1.1.tgz",
+			"integrity": "sha512-W+nOulP2tYd/ZG99WuZC/I5ljjQQ7EUw/jQGcIb9eu8mDlZxNY2SgcJXTLG9h5gRvqA3uJOe4hZXYsd3EqioMw==",
 			"dev": true,
 			"requires": {
 				"debug": "^4.1.0",
-				"extract-zip": "^1.6.6",
-				"https-proxy-agent": "^2.2.1",
-				"mime": "^2.0.3",
+				"devtools-protocol": "0.0.869402",
+				"extract-zip": "^2.0.0",
+				"https-proxy-agent": "^5.0.0",
+				"node-fetch": "^2.6.1",
+				"pkg-dir": "^4.2.0",
 				"progress": "^2.0.1",
-				"proxy-from-env": "^1.0.0",
-				"rimraf": "^2.6.1",
-				"ws": "^6.1.0"
+				"proxy-from-env": "^1.1.0",
+				"rimraf": "^3.0.2",
+				"tar-fs": "^2.0.0",
+				"unbzip2-stream": "^1.3.3",
+				"ws": "^7.2.3"
 			},
 			"dependencies": {
-				"ws": {
-					"version": "6.2.1",
-					"resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
-					"integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
+				"extract-zip": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+					"integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
 					"dev": true,
 					"requires": {
-						"async-limiter": "~1.0.0"
+						"@types/yauzl": "^2.9.1",
+						"debug": "^4.1.1",
+						"get-stream": "^5.1.0",
+						"yauzl": "^2.10.0"
 					}
+				},
+				"find-up": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+					"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+					"dev": true,
+					"requires": {
+						"locate-path": "^5.0.0",
+						"path-exists": "^4.0.0"
+					}
+				},
+				"locate-path": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+					"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+					"dev": true,
+					"requires": {
+						"p-locate": "^4.1.0"
+					}
+				},
+				"p-limit": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+					"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+					"dev": true,
+					"requires": {
+						"p-try": "^2.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+					"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+					"dev": true,
+					"requires": {
+						"p-limit": "^2.2.0"
+					}
+				},
+				"p-try": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+					"dev": true
+				},
+				"path-exists": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+					"dev": true
+				},
+				"pkg-dir": {
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+					"integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+					"dev": true,
+					"requires": {
+						"find-up": "^4.0.0"
+					}
+				},
+				"rimraf": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+					"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+					"dev": true,
+					"requires": {
+						"glob": "^7.1.3"
+					}
+				},
+				"ws": {
+					"version": "7.5.9",
+					"resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
+					"integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
+					"dev": true
 				}
 			}
 		},
@@ -19777,6 +20064,44 @@
 				"inherits": "2"
 			}
 		},
+		"tar-fs": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
+			"integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
+			"dev": true,
+			"requires": {
+				"chownr": "^1.1.1",
+				"mkdirp-classic": "^0.5.2",
+				"pump": "^3.0.0",
+				"tar-stream": "^2.1.4"
+			}
+		},
+		"tar-stream": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+			"integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+			"dev": true,
+			"requires": {
+				"bl": "^4.0.3",
+				"end-of-stream": "^1.4.1",
+				"fs-constants": "^1.0.0",
+				"inherits": "^2.0.3",
+				"readable-stream": "^3.1.1"
+			},
+			"dependencies": {
+				"readable-stream": {
+					"version": "3.6.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+					"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+					"dev": true,
+					"requires": {
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
+					}
+				}
+			}
+		},
 		"terser": {
 			"version": "4.6.10",
 			"resolved": "https://registry.npmjs.org/terser/-/terser-4.6.10.tgz",
@@ -20358,6 +20683,16 @@
 				"has-bigints": "^1.0.0",
 				"has-symbols": "^1.0.0",
 				"which-boxed-primitive": "^1.0.1"
+			}
+		},
+		"unbzip2-stream": {
+			"version": "1.4.3",
+			"resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
+			"integrity": "sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==",
+			"dev": true,
+			"requires": {
+				"buffer": "^5.2.1",
+				"through": "^2.3.8"
 			}
 		},
 		"undeclared-identifiers": {
@@ -21351,7 +21686,7 @@
 		"wordwrap": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-			"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+			"integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
 			"dev": true
 		},
 		"workbox-background-sync": {

--- a/package.json
+++ b/package.json
@@ -182,7 +182,7 @@
 		"node-sass": "^4.14.1",
 		"nyc": "^15.1.0",
 		"optimize-css-assets-webpack-plugin": "5.0.3",
-		"pa11y-ci": "^2.4.0",
+		"pa11y-ci": "^3.0.1",
 		"pnp-webpack-plugin": "1.6.4",
 		"postcss-flexbugs-fixes": "4.1.0",
 		"postcss-loader": "3.0.0",


### PR DESCRIPTION
Closes: #242 

Steps:

1. `nvm use v12`
2. Update `.pa11yci`
```
"chromeLaunchConfig": {
	"args": [
		"--no-sandbox",
		"--disable-setuid-sandbox",
		"--disable-dev-shm-usage"
	]
}
```
3. Run `npm install --save-dev pa11y-ci@^3.0.1`