### PR TITLE
(#246) Language toggle broken when otherLanguage prettyUrl is missing

### DIFF
--- a/src/views/Definition/Definition.jsx
+++ b/src/views/Definition/Definition.jsx
@@ -120,6 +120,10 @@ const Definition = () => {
 		if (langToggle && langObj.prettyUrlName) {
 			langToggle.href = `${altLanguageDictionaryBasePath}/def/${langObj.prettyUrlName}`;
 		}
+
+		if (langToggle && langObj.prettyUrlName == '') {
+			langToggle.href = `${altLanguageDictionaryBasePath}/def/${payload.termId}`;
+		}
 	};
 
 	const renderMetaDefinition = () => {


### PR DESCRIPTION
- When the otherLanguage structure has an empty prettyURLName field, the language toggle should now be created using the CDRID. 
Closes #246