### PR TITLE
(#245) Add Cypress coverage and merge with Jest

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,8 +1,4 @@
 const plugins = [];
-if (process.env.NODE_ENV === 'test') {
-	plugins.push(['istanbul']);
-}
-
 module.exports = {
 	presets: ['react-app'],
 	plugins,

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const fs = require('fs');
+const isWsl = require('is-wsl');
 const path = require('path');
 const webpack = require('webpack');
 const resolve = require('resolve');
@@ -371,20 +372,35 @@ module.exports = function (webpackEnv) {
 								customize: require.resolve(
 									'babel-preset-react-app/webpack-overrides'
 								),
-
-								plugins: [
-									[
-										require.resolve('babel-plugin-named-asset-import'),
-										{
-											loaderMap: {
-												svg: {
-													ReactComponent:
-														'@svgr/webpack?-svgo,+titleProp,+ref![path]',
+								// If this is development, then additionally add in the istanbul plugin
+								plugins: isEnvProduction
+									? [
+											[
+												require.resolve('babel-plugin-named-asset-import'),
+												{
+													loaderMap: {
+														svg: {
+															ReactComponent:
+																'@svgr/webpack?-svgo,+titleProp,+ref![path]',
+														},
+													},
 												},
-											},
-										},
-									],
-								],
+											],
+									  ]
+									: [
+											[
+												require.resolve('babel-plugin-named-asset-import'),
+												{
+													loaderMap: {
+														svg: {
+															ReactComponent:
+																'@svgr/webpack?-svgo,+titleProp,+ref![path]',
+														},
+													},
+												},
+											],
+											require.resolve('babel-plugin-istanbul'),
+									  ],
 								// This is a feature of `babel-loader` for webpack (not Babel itself).
 								// It enables caching results in ./node_modules/.cache/babel-loader/
 								// directory for faster rebuilds.

--- a/cypress/e2e/BasicTermPage/BasicTermPage.js
+++ b/cypress/e2e/BasicTermPage/BasicTermPage.js
@@ -1,4 +1,4 @@
-import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps';
+import { Then } from 'cypress-cucumber-preprocessor/steps';
 
 import { testIds } from '../../../src/constants';
 

--- a/cypress/e2e/common/MetaTags.js
+++ b/cypress/e2e/common/MetaTags.js
@@ -2,7 +2,7 @@
 import { Then } from 'cypress-cucumber-preprocessor/steps';
 
 Then('the page contains meta tags with the following names', (dataTable) => {
-	cy.document().then((doc) => {
+	cy.document().then(() => {
 		for (const { name, content } of dataTable.hashes()) {
 			const locator = `meta[name='${name}']`;
 			//find element, ensure it has attribute content
@@ -16,16 +16,16 @@ Then(
 	'the page contains meta tags with the following properties',
 	(dataTable) => {
 		for (const { property, content } of dataTable.hashes()) {
-			if(property==='robots'){
+			if (property === 'robots') {
 				const locator = 'META[name=robots]';
 				cy.get(locator).should('have.attr', 'content').and('be.eq', content);
-			}else {
-			const locator = `META[property='${property}']`;
-			//find element, ensure it has attribute content
-			//compare content's value with expected one
-			cy.get(locator).should('have.attr', 'content').and('be.eq', content);
+			} else {
+				const locator = `META[property='${property}']`;
+				//find element, ensure it has attribute content
+				//compare content's value with expected one
+				cy.get(locator).should('have.attr', 'content').and('be.eq', content);
+			}
 		}
-	}
 	}
 );
 

--- a/cypress/e2e/common/analytics.js
+++ b/cypress/e2e/common/analytics.js
@@ -1,5 +1,5 @@
 /// <reference types="Cypress" />
-import { And, Given, Then, When } from 'cypress-cucumber-preprocessor/steps';
+import { Then, When } from 'cypress-cucumber-preprocessor/steps';
 
 /**
  * Converts a string value to a native data type if indicated in the map.
@@ -8,11 +8,11 @@ import { And, Given, Then, When } from 'cypress-cucumber-preprocessor/steps';
 const convertValue = (val) => {
 	if (typeof val === 'string') {
 		if (val.indexOf('(int)') === 0) {
-			return parseInt(val.replace('(int)', ''))
+			return parseInt(val.replace('(int)', ''));
 		}
 	}
 	return val;
-}
+};
 
 /**
  * Converts an object with a.b.c styled keys into an
@@ -20,71 +20,61 @@ const convertValue = (val) => {
  * @param {object} obj The DataTable.hashes()
  */
 const convertAnalyticsDatatableObject = (obj) => {
-  const objPass1 = Object.keys(obj)
-    .map(key => {
+	const objPass1 = Object.keys(obj)
+		.map((key) => {
 			const [first, ...rest] = key.split('.');
-      if (rest.length > 0) {
+			if (rest.length > 0) {
 				const newRestKey = rest.join('.');
 				const value = convertValue(obj[first + '.' + newRestKey]);
-        return {
-          first,
-          rest: {
-            [newRestKey]: value
-          }
-        }
-      } else {
-        return {
-          first,
-          value: obj[first]
-        }
-      }
-    })
-    .reduce(
-      (ac,curr) => {
-        const newKey = curr.first;
+				return {
+					first,
+					rest: {
+						[newRestKey]: value,
+					},
+				};
+			} else {
+				return {
+					first,
+					value: obj[first],
+				};
+			}
+		})
+		.reduce((ac, curr) => {
+			const newKey = curr.first;
 
-        if (curr.value) {
-          if (ac[newKey]) {
-            throw new Error(`Key, ${newKey}, is already defined.`);
-          }
-          return {
-            [newKey]: curr.value,
-            ...ac
-          }
-        } else if (curr.rest) {
-          if (ac[newKey] && typeof ac[newKey] !== 'object') {
-            throw new Error(`Key, ${newKey}, is mixing values and objects.`);
-          }
+			if (curr.value) {
+				if (ac[newKey]) {
+					throw new Error(`Key, ${newKey}, is already defined.`);
+				}
+				return {
+					[newKey]: curr.value,
+					...ac,
+				};
+			} else if (curr.rest) {
+				if (ac[newKey] && typeof ac[newKey] !== 'object') {
+					throw new Error(`Key, ${newKey}, is mixing values and objects.`);
+				}
 
-          return {
-            ...ac,
-            [newKey]: {
-              ...ac[newKey],
-              ...curr.rest
-            }
-          }
-
-        } else {
-          // This is not good
-          return ac;
-        }
-      },
-      {}
-    );
-  return Object.entries(objPass1)
-    .reduce(
-      (ac, [key, val] = {}) => {
-        return {
-          ...ac,
-          [key]: (typeof val === "object") ?
-					convertAnalyticsDatatableObject(val) :
-            val
-        }
-      },
-      {}
-    );
-
-}
+				return {
+					...ac,
+					[newKey]: {
+						...ac[newKey],
+						...curr.rest,
+					},
+				};
+			} else {
+				// This is not good
+				return ac;
+			}
+		}, {});
+	return Object.entries(objPass1).reduce((ac, [key, val] = {}) => {
+		return {
+			...ac,
+			[key]:
+				typeof val === 'object' ? convertAnalyticsDatatableObject(val) : val,
+		};
+	}, {});
+};
 
 /**
  * Finds an event with the following information.
@@ -92,7 +82,9 @@ const convertAnalyticsDatatableObject = (obj) => {
  * @param {string} event The name of the event
  */
 const getEventFromEDDL = (win, type, event) => {
-	return win.NCIDataLayer.filter(evt => evt.type === type && evt.event === event);
+	return win.NCIDataLayer.filter(
+		(evt) => evt.type === type && evt.event === event
+	);
 };
 
 When('the NCIDataLayer is cleared', () => {
@@ -122,16 +114,16 @@ Then(
 				}
 				return {
 					...ac,
-					[key]: val
-				}
-			}, {})
+					[key]: val,
+				};
+			}, {});
 
 			if (!dataObj.event) {
-				throw new Error("Datatable is missing the event name")
+				throw new Error('Datatable is missing the event name');
 			}
 
 			if (!dataObj.type) {
-				throw new Error("Datatable is missing the event type")
+				throw new Error('Datatable is missing the event type');
 			}
 
 			// Find the matching events, this should be only one.

--- a/cypress/e2e/common/index.js
+++ b/cypress/e2e/common/index.js
@@ -14,7 +14,7 @@ Then('the page title is {string}', (title) => {
 });
 
 Then('page title on error page is {string}', (title) => {
-	Cypress.on('uncaught:exception', (err, runnable) => {
+	Cypress.on('uncaught:exception', () => {
 		// returning false here to Cypress from
 		// failing the test
 		return false;
@@ -52,8 +52,7 @@ Given('user is on landing Genetics Terms page', () => {
 });
 
 And('the system appends {string} to the URL', (a) => {
-	cy.location('search').should('eq',a)
-
+	cy.location('search').should('eq', a);
 });
 
 Given(
@@ -84,7 +83,9 @@ When('user is searching {string} for the term {string}', (searchMode, term) => {
 				win.INT_TEST_APP_PARAMS.language === 'en'
 					? queryType.SEARCH
 					: queryType.SEARCH_SPANISH;
-			cy.visit(`/${searchLang}/${encodeURIComponent(term)}/?searchMode=${searchmode}`);
+			cy.visit(
+				`/${searchLang}/${encodeURIComponent(term)}/?searchMode=${searchmode}`
+			);
 		}
 	});
 });
@@ -317,7 +318,7 @@ Then(
 	}
 );
 
-Then('{string} search box appears', (keywords) => {
+Then('{string} search box appears', () => {
 	cy.get('input.dictionary-search-input');
 });
 
@@ -452,7 +453,7 @@ Then(
 
 When(
 	'user tries to go to this URL, system should return the Expand {string} page for language {string}',
-	(text, lang) => {
+	() => {
 		cy.window().then((win) => {
 			if (win.INT_TEST_APP_PARAMS) {
 				const { language } = win.INT_TEST_APP_PARAMS;
@@ -468,7 +469,10 @@ When(
 Then(
 	'the system returns user to the search results page for the search term {string} URL has {string}',
 	(term, destURL) => {
-		cy.location('href').should('eq', `${baseURL}${destURL}/${encodeURIComponent(term)}`);
+		cy.location('href').should(
+			'eq',
+			`${baseURL}${destURL}/${encodeURIComponent(term)}`
+		);
 	}
 );
 
@@ -575,15 +579,24 @@ And('introductory text appears below the page title', () => {
 	expect(cy.get(`div[data-testid='${testIds.INTRO_TEXT}']`)).to.exist;
 });
 
-And('the user sees {string} as the introductory text that displays below the H1', (introText) => {
-	cy.get(`div[data-testid='${testIds.INTRO_TEXT}']`).should('have.text', introText);
-});
+And(
+	'the user sees {string} as the introductory text that displays below the H1',
+	(introText) => {
+		cy.get(`div[data-testid='${testIds.INTRO_TEXT}']`).should(
+			'have.text',
+			introText
+		);
+	}
+);
 
 And('the term count of {string} is displayed as bolded', (termCount) => {
-	cy.get(`div[data-testid='${testIds.INTRO_TEXT}'] strong`).should('have.text', termCount);
+	cy.get(`div[data-testid='${testIds.INTRO_TEXT}'] strong`).should(
+		'have.text',
+		termCount
+	);
 });
 
-And('{string} radio is selected by default', (startsWithRadio) => {
+And('{string} radio is selected by default', () => {
 	const startsWithRadioValue = searchMatchType.beginsWith;
 	cy.get(`input[value="${startsWithRadioValue}"]`).should('be.checked');
 });
@@ -625,7 +638,7 @@ And('the URL does not include {string}', (expandURL) => {
 	cy.location('href').should('not.include', `${baseURL}/${expandURL}`);
 });
 
-Then('{string} exists in the data for the page', (noIndexDirective) => {
+Then('{string} exists in the data for the page', () => {
 	cy.get('head meta[name="robots"]').should('have.attr', 'content', 'index');
 });
 
@@ -646,7 +659,7 @@ Then('the language toggle should have the URL path {string}', (urlPath) => {
 */
 
 Then('the user gets an error page that reads {string}', (errorMessage) => {
-	Cypress.on('uncaught:exception', (err, runnable) => {
+	Cypress.on('uncaught:exception', () => {
 		// returning false here to Cypress from
 		// failing the test
 		return false;
@@ -724,9 +737,7 @@ Then('URL contains selected term', () => {
 		const decoded = decodeURIComponent(win.location.pathname);
 		const lang = win.INT_TEST_APP_PARAMS.language;
 		if (lang === 'en') expect(decoded).to.eq(`/search/${Cypress.TERM_TEXT}/`);
-		else expect(decoded).to.eq(
-						`/buscar/${Cypress.TERM_TEXT}/`
-					);
+		else expect(decoded).to.eq(`/buscar/${Cypress.TERM_TEXT}/`);
 	});
 });
 
@@ -793,4 +804,3 @@ And('the user enters {string}', (userText) => {
 And('the user submits the keyword search', () => {
 	cy.get('#btnSearch').click();
 });
-

--- a/cypress/e2e/common/search.js
+++ b/cypress/e2e/common/search.js
@@ -1,5 +1,5 @@
 /// <reference types="Cypress" />
-import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps';
+import { When, Then } from 'cypress-cucumber-preprocessor/steps';
 import { searchMatchType, testIds } from '../../../src/constants';
 
 When('user clicks on {string} button', (searchButton) => {
@@ -7,9 +7,9 @@ When('user clicks on {string} button', (searchButton) => {
 });
 
 When('user selects {string} option', (startsWithOrContains) => {
-  let locator;
-  const queryType = startsWithOrContains.toLowerCase();
-	if (( queryType === 'contains') || (queryType === 'contiene')) {
+	let locator;
+	const queryType = startsWithOrContains.toLowerCase();
+	if (queryType === 'contains' || queryType === 'contiene') {
 		locator = "label[for='contains']";
 	} else {
 		locator = "label[for='starts-with']";

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -24,7 +24,7 @@
 // -- This will overwrite an existing command --
 // Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })
 
-Cypress.on('uncaught:exception', (err, runnable) => {
+Cypress.on('uncaught:exception', (err) => {
 	// returning false here prevents Cypress from
 	// failing the test
 	console.log('Cypress detected uncaught exception', err);

--- a/merged.nyc.config.js
+++ b/merged.nyc.config.js
@@ -1,0 +1,23 @@
+'use strict';
+
+/******
+ * This file is the configuration for the final merged report.
+ */
+module.exports = {
+	'report-dir': 'coverage/merged',
+	'temp-dir': 'coverage/merged',
+	reporter: ['html', 'json', 'lcov', 'text'],
+	'check-coverage': true,
+	branches: 80,
+	lines: 80,
+	functions: 80,
+	statements: 80,
+	include: ['src/'],
+	exclude: [
+		'cypress/**/*.js',
+		'jest-test-setup.js',
+		'src/serviceWorker.js',
+		'src/setupTests.js',
+		'*.test.js',
+	],
+};

--- a/nyc.config.js
+++ b/nyc.config.js
@@ -1,0 +1,16 @@
+'use strict';
+
+/******
+ * This file is the configuration for the final merged report.
+ */
+module.exports = {
+	'report-dir': 'coverage/cypress',
+	reporter: ['html', 'json', 'lcov'],
+	exclude: [
+		'cypress/**/*.js',
+		'jest-test-setup.js',
+		'src/serviceWorker.js',
+		'src/setupTests.js',
+		'*.test.js',
+	],
+};

--- a/package.json
+++ b/package.json
@@ -43,22 +43,29 @@
 	},
 	"scripts": {
 		"start": "node scripts/start.js",
+		"start:silent": "BROWSER=none npm start",
 		"build:cgdp-legacy": "node scripts/generate-cgdp-legacy.js",
 		"build:cra": "node scripts/build.js",
 		"build": "npm run build:cra && npm run build:cgdp-legacy",
-		"test": "NODE_ENV=test npm run lint && NODE_ENV=test npm run pa11y-tests && NODE_ENV=test npm run unit-tests && NODE_ENV=test npm run cy:ci",
-		"posttest": "npm run prepare-reports",
+		"test": "npm run unit-tests && npm run cy:ci && npm run merge-coverage",
 		"test:it": "NODE_ENV=test cypress open",
 		"test:pa11y": "./node_modules/.bin/pa11y-ci",
 		"pa11y-tests": "start-server-and-test start http://localhost:3000 pa11y",
-		"pa11y": "NODE_ENV=test pa11y-ci",
-		"cy:ci": "start-server-and-test start http://localhost:3000 integration-tests",
+		"pa11y": "pa11y-ci",
+		"cy:ci": "start-server-and-test start:silent http://localhost:3000 integration-tests",
 		"unit-tests": "jest",
-		"integration-tests": "cypress run",
-		"prepare-reports": "cp coverage/cypress/index.html coverage/from-cypress.html && cp coverage/jest/lcov-report/index.html coverage/from-jest.html",
+		"integration-tests": "NODE_ENV=test cypress run && nyc report -t coverage/cypress --reporter text --report-dir coverage/cypress",
+		"merge-coverage": "npm run mc:pre && npm run mc:merge && npm run mc:report",
+		"mc:pre": "node scripts/pre-merge-coverage",
+		"mc:merge": "nyc merge coverage/tmp coverage/merged/coverage-final.json",
+		"mc:report": "nyc report --nycrc-path=merged.nyc.config.js",
 		"format": "prettier --write \"**/*.+(js|jsx|json|css|md)\"",
-		"lint": "eslint src --ext .js,.jsx",
-		"lint:fix": "eslint src --ext .js,.jsx --fix"
+		"lint": "npm run lint:src && npm run lint:cypress",
+		"lint:src": "eslint src --ext .js,.jsx",
+		"lint:cypress": "eslint cypress/e2e --ext .js,.jsx",
+		"lint:fix": "npm run lint:src:fix && npm run lint:cypress:fix",
+		"lint:src:fix": "eslint src --ext .js,.jsx --fix",
+		"lint:cypress:fix": "eslint cypress/e2e --ext .js,.jsx --fix"
 	},
 	"browserslist": {
 		"production": [
@@ -81,15 +88,18 @@
 		"collectCoverage": true,
 		"coverageDirectory": "coverage/jest",
 		"collectCoverageFrom": [
-			"src/**/*.test.{js,jsx,ts,tsx}",
+			"src/**/*.{js,jsx,ts,tsx}",
+			"!src/**/*.test.{js,jsx,ts,tsx}",
 			"!src/**/*.d.ts",
-			"!cypress/**/*.{spec,test}.{js,jsx,ts,tsx}"
+			"!cypress/**/*.{spec,test}.{js,jsx,ts,tsx}",
+			"!src/setupTests.js",
+			"!src/serviceWorker.js"
 		],
 		"coverageThreshold": {
 			"global": {
-				"branches": 85,
-				"functions": 85,
-				"lines": 85
+				"branches": 80,
+				"functions": 80,
+				"lines": 80
 			}
 		},
 		"setupFiles": [
@@ -102,6 +112,7 @@
 		"testMatch": [
 			"<rootDir>/src/**/__tests__/**/*.{js,jsx,ts,tsx}",
 			"<rootDir>/src/**/*.test.{js,jsx,ts,tsx}"
+
 		],
 		"testEnvironment": "jest-environment-jsdom-global",
 		"transform": {
@@ -140,12 +151,7 @@
 		"stepDefinitions": "cypress/e2e",
 		"commonPath": "cypress/e2e/common"
 	},
-	"nyc": {
-		"report-dir": "coverage/cypress",
-		"reporter": [
-			"html"
-		]
-	},
+
 	"devDependencies": {
 		"@babel/core": "7.9.0",
 		"@cypress/code-coverage": "^3.10.0",

--- a/scripts/pre-merge-coverage.js
+++ b/scripts/pre-merge-coverage.js
@@ -1,0 +1,38 @@
+'use strict';
+
+const path = require('path');
+const fs = require('fs-extra');
+
+// Makes the script crash on unhandled rejections instead of silently
+// ignoring them. In the future, promise rejections that are not handled will
+// terminate the Node.js process with a non-zero exit code.
+process.on('unhandledRejection', (err) => {
+	throw err;
+});
+
+// Make sure any symlinks in the project folder are resolved:
+// https://github.com/facebook/create-react-app/issues/637
+const appDirectory = fs.realpathSync(process.cwd());
+const resolveApp = (relativePath) => path.resolve(appDirectory, relativePath);
+
+const main = async () => {
+	try {
+		// Create, or empty, a tmp folder for the two coverage files.
+		await fs.emptyDir(resolveApp('coverage/tmp'));
+		// Copy the Jest coverage file
+		await fs.copy(
+			resolveApp('coverage/jest/coverage-final.json'),
+			resolveApp('coverage/tmp/jest-final.json')
+		);
+		// Copy the Cypress coverage
+		await fs.copy(
+			resolveApp('coverage/cypress/coverage-final.json'),
+			resolveApp('coverage/tmp/cypress-final.json')
+		);
+	} catch (err) {
+		console.error(err);
+		process.exit(1);
+	}
+};
+
+main();

--- a/src/components/atomic/Autocomplete/Autocomplete.jsx
+++ b/src/components/atomic/Autocomplete/Autocomplete.jsx
@@ -235,7 +235,6 @@ class Autocomplete extends React.Component {
 		this.handleChange = this.handleChange.bind(this);
 		this.handleKeyDown = this.handleKeyDown.bind(this);
 		this.handleInputClick = this.handleInputClick.bind(this);
-		this.maybeAutoCompleteText = this.maybeAutoCompleteText.bind(this);
 
 		this.id = this.props.id;
 		this.dropdown = createRef();
@@ -402,30 +401,6 @@ class Autocomplete extends React.Component {
 		}
 
 		return items;
-	}
-
-	maybeAutoCompleteText(state, props) {
-		const { highlightedIndex } = state;
-		const { value, getItemValue } = props;
-		let index = highlightedIndex === null ? 0 : highlightedIndex;
-		let items = this.getFilteredItems(props);
-		for (let i = 0; i < items.length; i++) {
-			if (props.isItemSelectable(items[index])) break;
-			index = (index + 1) % items.length;
-		}
-		const matchedItem =
-			items[index] && props.isItemSelectable(items[index])
-				? items[index]
-				: null;
-		if (value !== '' && matchedItem) {
-			const itemValue = getItemValue(matchedItem);
-			const itemValueDoesMatch =
-				itemValue.toLowerCase().indexOf(value.toLowerCase()) === 0;
-			if (itemValueDoesMatch) {
-				return { highlightedIndex: index };
-			}
-		}
-		return { highlightedIndex: null };
 	}
 
 	ensureHighlightedIndex(state, props) {

--- a/src/components/atomic/Autocomplete/__tests__/Autocomplete.tests.js
+++ b/src/components/atomic/Autocomplete/__tests__/Autocomplete.tests.js
@@ -630,6 +630,16 @@ describe('<Autocomplete />', () => {
 		expect(ref.current._scrollOffset).toEqual(null);
 	});
 
+	test('should save scroll position with undefined offset', () => {
+		const ref = React.createRef();
+		window.pageXOffset = undefined;
+		window.pageYOffset = undefined;
+		render(<Autocomplete {...defaultProps} ref={ref} debug />);
+		expect(ref.current._scrollOffset).toBe(null);
+		ref.current._ignoreBlur = true;
+		ref.current.handleInputBlur();
+		expect(ref.current._scrollOffset).toEqual(null);
+	});
 	test('should open menu if it is closed when input is clicked', () => {
 		const ref = React.createRef();
 		render(<Autocomplete {...defaultProps} ref={ref} />);

--- a/src/components/atomic/TextInput/__tests__/TextInput.test.js
+++ b/src/components/atomic/TextInput/__tests__/TextInput.test.js
@@ -99,10 +99,9 @@ describe('TextInput component', function () {
 
 			const setErrorMessage = ({ event }) => {
 				const { value } = event.target;
+				errorMessage = '';
 				if (value === 'error') {
 					errorMessage = `You typed in "${value}" which generated an error`;
-				} else {
-					errorMessage = '';
 				}
 			};
 

--- a/src/components/molecules/related-resource-list/related-resource-list.jsx
+++ b/src/components/molecules/related-resource-list/related-resource-list.jsx
@@ -45,10 +45,12 @@ const RelatedResourceList = ({ linksArr, lang = 'en' }) => {
 
 RelatedResourceList.propTypes = {
 	lang: PropTypes.oneOf(['en', 'es']),
-	linksArr: PropTypes.shape({
-		length: PropTypes.number,
-		map: PropTypes.func,
-	}).isRequired,
+	linksArr: PropTypes.arrayOf(
+		PropTypes.shape({
+			length: PropTypes.number,
+			map: PropTypes.func,
+		})
+	).isRequired,
 };
 
 export default RelatedResourceList;


### PR DESCRIPTION
**Adding Cypress and global Coverage**
   * Added pre-merge script to setup comined coverage directories and copy coverage files from cypress and jest.
   * Added  a merged coverage specific config, and separated out the cypress nyc config from package.json.
   * Added text reporting after ALL integration tests finish. When text reporting is enabled Cypress reports after each feature.
   * Added reporting for full merged coverage at the end with coverage checking set to 80%.
   * Installed  @cypress/code-coverage


Addresses additional changes as described here :
https://github.com/NCIOCPL/cgov-react-app-playground/issues/90

**Boosting Coverage to 80%**

  * Updates coverage level to 80% across the board
  * Removes test files from coverage
  * Removes Create React App serviceWorker.js and setupTests.js from coverage
  * Fixes props for RelatedResourceList
  * Adds additional unit tests and makes minor modifications

**Boosting Coverage to 80%**
Fixes Cypress Linting Issues
  Closes #245