### PR TITLE
(#283) Fix For Pronunciation Player Cypress Test Failure

### DIFF
--- a/cypress/e2e/PronunciationPlayer/PronunciationPlayer.js
+++ b/cypress/e2e/PronunciationPlayer/PronunciationPlayer.js
@@ -21,10 +21,13 @@ When('the user clicks the audio speaker icon', () => {
 });
 
 Then('the pronunciation for {string} should play', (def) => {
-	cy.get("div.pronunciation button[class='btnAudio playing']").should('exist');
 	cy.document().then((doc) => {
-		let current = doc.querySelector('div.pronunciation__audio audio')
-			.currentTime;
+		cy.get("div.pronunciation button[class='btnAudio playing']").should(
+			'exist'
+		);
+		let current = doc.querySelector(
+			'div.pronunciation__audio audio'
+		).currentTime;
 		expect(current).to.be.greaterThan(0);
 	});
 });


### PR DESCRIPTION
  (#283) Fix For Pronunciation Player Cypress Test Failure

  *  Re-orders the logic for element detection

  Closes #283