### PR TITLE
(#293) Add prerender status code tags

### DIFF
--- a/cypress/e2e/PageNotFoundEnglish.feature
+++ b/cypress/e2e/PageNotFoundEnglish.feature
@@ -7,3 +7,6 @@ Feature: Page Not Found Error
 				|	https://www.cancer.gov | homepage	|
 				| https://www.cancer.gov/types | cancer type	|
 				|	https://www.cancer.gov/contact | Get in touch	|
+		And the page contains meta tags with the following names
+            | name                  | content |
+            | prerender-status-code | 404     |

--- a/cypress/e2e/PageNotFoundSpanish.feature
+++ b/cypress/e2e/PageNotFoundSpanish.feature
@@ -10,3 +10,6 @@ Feature: Page Not Found Error Spanish
 				|	https://www.cancer.gov/espanol | página principal	|
 				| https://www.cancer.gov/espanol/tipos | tipo de cáncer	|
 				|	https://www.cancer.gov/espanol/contactenos | Contáctenos	|
+		And the page contains meta tags with the following names
+            | name                  | content |
+            | prerender-status-code | 404     |

--- a/cypress/e2e/PrettyUrlRedirect.feature
+++ b/cypress/e2e/PrettyUrlRedirect.feature
@@ -4,3 +4,7 @@ Scenario: As a user, if my term's page URL contains an ID, I would like to be re
   Given the user is viewing the definition with the ID "44058"
   Then the user is redirected to "/def/metastatic"
   And the system appends '?redirect=true' to the URL
+  And the page contains meta tags with the following names
+            | name                  | content 																				|
+            | prerender-status-code | 301     																				|
+						| prerender-header 			| Location: http://localhost:3000/def/metastatic	|

--- a/cypress/e2e/common/index.js
+++ b/cypress/e2e/common/index.js
@@ -35,6 +35,13 @@ Given('the user visits the home page', () => {
 	cy.visit('/');
 });
 
+// Used when we don't want to automatically fail the test when non-200 responses are encountered.
+Given('the user navigates to {string} with error handling', (destURL) => {
+	cy.visit(destURL, {
+		failOnStatusCode: false,
+	});
+});
+
 Given('user is on the dictionary landing page or results page', () => {
 	cy.visit(baseURL);
 });
@@ -665,6 +672,25 @@ Then('the user gets an error page that reads {string}', (errorMessage) => {
 		return false;
 	});
 	cy.get('.error-container h1').should('have.text', errorMessage);
+});
+
+// Intercepts CTS API Calls
+Cypress.Commands.add('triggerServerError', () => {
+	cy.intercept('/cts/mock-api/v2/*', {
+		statusCode: 500,
+	}).as('mockApiError');
+
+	cy.intercept('/cts/proxy-api/v2/*', {
+		statusCode: 500,
+	}).as('proxyApiError');
+
+	cy.intercept('https://clinicaltrialsapi.cancer.gov/api/v2/*', {
+		statusCode: 500,
+	}).as('ctsApiError');
+});
+
+And('the CTS API is responding with a server error', () => {
+	cy.triggerServerError();
 });
 
 /*

--- a/src/views/Definition/Definition.jsx
+++ b/src/views/Definition/Definition.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from 'react';
 import { Helmet } from 'react-helmet';
 import { useNavigate, useParams } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import track, { useTracking } from 'react-tracking';
 import {
 	FigureCgovImage,
@@ -68,6 +69,7 @@ const Definition = () => {
 	] = useStateValue();
 	const navigate = useNavigate();
 	const tracking = useTracking();
+	const location = useLocation();
 
 	useEffect(() => {
 		window.scrollTo(0, 0);
@@ -141,8 +143,27 @@ const Definition = () => {
 		return definitionSplit;
 	};
 
+	const preRenderHandler = () => {
+		const preRenderObj = {};
+
+		if (location.search === '?redirect=true') {
+			preRenderObj.statusCode = (
+				<meta name="prerender-status-code" content="301" />
+			);
+			preRenderObj.headerLocation = (
+				<meta
+					name="prerender-header"
+					content={'Location: ' + baseHost + window.location.pathname}
+				/>
+			);
+		}
+
+		return preRenderObj;
+	};
+
 	const renderHelmet = () => {
 		let definition = renderMetaDefinition();
+		const preRender = preRenderHandler();
 
 		if (
 			altLanguageDictionaryBasePath &&
@@ -171,6 +192,8 @@ const Definition = () => {
 					/>
 					<meta name="description" content={definition} />
 					<meta property="og:description" content={definition} />
+					{preRender.statusCode}
+					{preRender.headerLocation}
 					<link
 						rel="canonical"
 						href={
@@ -229,6 +252,8 @@ const Definition = () => {
 					/>
 					<meta name="description" content={definition} />
 					<meta property="og:description" content={definition} />
+					{preRender.statusCode}
+					{preRender.headerLocation}
 					<link
 						rel="canonical"
 						href={

--- a/src/views/ErrorBoundary/ErrorPage.jsx
+++ b/src/views/ErrorBoundary/ErrorPage.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect } from 'react';
 import { useTracking } from 'react-tracking';
+import { Helmet } from 'react-helmet';
 
 import { useStateValue } from '../../store/store';
 import { i18n } from '../../utils';
@@ -21,10 +22,24 @@ const ErrorPage = () => {
 		});
 	}, []);
 
+	const renderHelmet = () => {
+		return (
+			<Helmet>
+				<title>Errors Occurred</title>
+				<meta property="dcterms.subject" content="Error Pages" />
+				<meta property="dcterms.type" content="errorpage" />
+				<meta name="prerender-status-code" content="500" />
+			</Helmet>
+		);
+	};
+
 	return (
-		<div className="error-container">
-			<h1>{i18n.errorPageText[language]}</h1>
-		</div>
+		<>
+			{renderHelmet()}
+			<div className="error-container">
+				<h1>{i18n.errorPageText[language]}</h1>
+			</div>
+		</>
 	);
 };
 

--- a/src/views/ErrorBoundary/PageNotFound.jsx
+++ b/src/views/ErrorBoundary/PageNotFound.jsx
@@ -76,6 +76,9 @@ const PageNotFound = () => {
 		return (
 			<Helmet>
 				<title>{i18n.pageNotFoundTitle[language]}</title>
+				<meta property="dcterms.subject" content="Error Pages" />
+				<meta property="dcterms.type" content="errorpage" />
+				<meta name="prerender-status-code" content="404" />
 			</Helmet>
 		);
 	};


### PR DESCRIPTION
- Added prerender status code tags to PageNotFound, ErrorPage, and Definition
- Updated PageNotFound and PrettyUrlRedirect cypress tests
- Started adding in cypress tests for ErrorPage

Closes #293